### PR TITLE
WIP: Support for Elucubratus APT::Format::JSON output format

### DIFF
--- a/Sileo/Backend/APT Wrapper/APTWrapper.swift
+++ b/Sileo/Backend/APT Wrapper/APTWrapper.swift
@@ -143,14 +143,7 @@ class APTWrapper {
                 fullJsonParseMode = true
                 fullJsonToParse.append(aptLine)
             } else if fullJsonParseMode {
-                // TODO: We can remove the workaround for the final line when Sam adds \n after the
-                // JSON output. Currently it ends up like "}6 upgraded, 0 newly installed, …".
-                if aptLine.hasPrefix("}") {
-                    fullJsonToParse.append("}")
-                    break
-                } else {
-                    fullJsonToParse.append(aptLine)
-                }
+                fullJsonToParse.append(aptLine)
             } else if aptLine.hasPrefix("{") && aptLine.hasSuffix("}") {
                 guard let aptOp = try? JSONSerialization.jsonObject(with: aptLine.data(using: .utf8) ?? Data(),
                                                                     options: []) as? [String: String] else {
@@ -182,14 +175,15 @@ class APTWrapper {
             if let operations = json["operations"] as? [[String: String]] {
                 for aptOp in operations {
                     if let type = aptOp["Type"],
-                        let packageID = aptOp["Package"],
-                        let version = aptOp["CandidateVersion"] {
-                        if type == "Inst"{
+                        let packageID = aptOp["Package"] {
+                        if type == "Inst",
+                            let version = aptOp["CandidateVersion"] {
                             packageInstalls.append([
                                 "package": packageID,
                                 "version": version
                             ])
-                        } else if type == "Remv" || type == "Purg" {
+                        } else if type == "Remv" || type == "Purg",
+                            let version = aptOp["CurrentVersion"] {
                             packageRemovals.append([
                                 "package": packageID,
                                 "version": version

--- a/Sileo/UI/PackageViewController/DepictionView/DepictionAutoStackView/DepictionAutoStackView.swift
+++ b/Sileo/UI/PackageViewController/DepictionView/DepictionAutoStackView/DepictionAutoStackView.swift
@@ -34,24 +34,6 @@ class DepictionAutoStackView: DepictionBaseView {
             }
         }
         
-        if let packageViewController = viewController as? PackageViewController,
-            let repo = packageViewController.package?.sourceRepo,
-            let host = repo.url?.host?.lowercased(),
-            host.contains("nepeta.me") {
-            if dictionary["backgroundColor"] as? String == nil,
-                views.count == 1,
-                let viewClass = views[0]["class"] as? String,
-                (viewClass == "DepictionHeaderView" ||
-                    viewClass == "DepictionSubheaderView" ||
-                    viewClass == "DepictionMarkdownView" ||
-                    viewClass == "DepictionLabelView" ||
-                    viewClass == "DepictionStackView" ||
-                    viewClass == "DepictionTableTextView" ||
-                    viewClass == "DepictionTableButtonView") {
-                return nil
-            }
-        }
-
         super.init(dictionary: dictionary, viewController: viewController, tintColor: tintColor)
         for viewDict in views {
             guard let preferredWidth = viewDict["preferredWidth"] as? CGFloat else {

--- a/Sileo/UI/PackageViewController/DepictionView/DepictionMarkdownView/DepictionMarkdownViewFast.swift
+++ b/Sileo/UI/PackageViewController/DepictionView/DepictionMarkdownView/DepictionMarkdownViewFast.swift
@@ -25,24 +25,6 @@ class DepictionMarkdownView: DepictionBaseView, CSTextViewActionHandler {
             return nil
         }
         
-        if let packageViewController = viewController as? PackageViewController,
-            let repo = packageViewController.package?.sourceRepo,
-            let host = repo.url?.host?.lowercased(),
-            host.contains("nepeta.me") {
-            let lowerMarkdown = markdown.lowercased()
-            let search1 = ["package", "apt", "repo"]
-            let search2 = ["manager", "browser", "downloader", "installer"]
-            guard search1.filter({ lowerMarkdown.contains($0) }).isEmpty || search2.filter({ lowerMarkdown.contains($0) }).isEmpty else {
-                return nil
-            }
-            
-            let search4 = ["link", "get", "download", "install", "view", "preview", "try"]
-            let search5 = ["zebra", "installer", "cydia", "manager"]
-            guard search4.filter({ lowerMarkdown.contains($0) }).isEmpty || search5.filter({ lowerMarkdown.contains($0) }).isEmpty else {
-                return nil
-            }
-        }
-        
         useSpacing = (dictionary["useSpacing"] as? Bool) ?? true
         useMargins = (dictionary["useMargins"] as? Bool) ?? true
 

--- a/Sileo/UI/PackageViewController/DepictionView/DepictionMarkdownView/DepictionMarkdownViewSlow.swift
+++ b/Sileo/UI/PackageViewController/DepictionView/DepictionMarkdownView/DepictionMarkdownViewSlow.swift
@@ -25,24 +25,6 @@ class DepictionMarkdownViewSlow: DepictionBaseView, CSTextViewActionHandler {
             return nil
         }
         
-        if let packageViewController = viewController as? PackageViewController,
-            let repo = packageViewController.package?.sourceRepo,
-            let host = repo.url?.host?.lowercased(),
-            host.contains("nepeta.me") {
-            let lowerMarkdown = markdown.lowercased()
-            let search1 = ["package", "apt", "repo"]
-            let search2 = ["manager", "browser", "downloader", "installer"]
-            guard search1.filter({ lowerMarkdown.contains($0) }).isEmpty || search2.filter({ lowerMarkdown.contains($0) }).isEmpty else {
-                return nil
-            }
-            
-            let search4 = ["link", "get", "download", "install", "view", "preview", "try"]
-            let search5 = ["zebra", "installer", "cydia", "manager"]
-            guard search4.filter({ lowerMarkdown.contains($0) }).isEmpty || search5.filter({ lowerMarkdown.contains($0) }).isEmpty else {
-                return nil
-            }
-        }
-        
         useSpacing = (dictionary["useSpacing"] as? Bool) ?? true
         useMargins = (dictionary["useMargins"] as? Bool) ?? true
 

--- a/Sileo/UI/PackageViewController/DepictionView/DepictionStackView/DepictionStackView.swift
+++ b/Sileo/UI/PackageViewController/DepictionView/DepictionStackView/DepictionStackView.swift
@@ -35,24 +35,6 @@ class DepictionStackView: DepictionBaseView {
             }
         }
         
-        if let packageViewController = viewController as? PackageViewController,
-            let repo = packageViewController.package?.sourceRepo,
-            let host = repo.url?.host?.lowercased(),
-            host.contains("nepeta.me") {
-            if dictionary["backgroundColor"] as? String != nil,
-                views.count == 1,
-                let viewClass = views[0]["class"] as? String,
-                (viewClass == "DepictionHeaderView" ||
-                    viewClass == "DepictionSubheaderView" ||
-                    viewClass == "DepictionMarkdownView" ||
-                    viewClass == "DepictionLabelView" ||
-                    viewClass == "DepictionStackView" ||
-                    viewClass == "DepictionTableTextView" ||
-                    viewClass == "DepictionTableButtonView") {
-                return nil
-            }
-        }
-
         super.init(dictionary: dictionary, viewController: viewController, tintColor: tintColor)
         for viewDict in views {
             if let view = DepictionBaseView.view(dictionary: viewDict, viewController: viewController, tintColor: tintColor) {

--- a/Sileo/UI/PackageViewController/DepictionView/DepictionTableButtonView/DepictionTableButtonView.swift
+++ b/Sileo/UI/PackageViewController/DepictionView/DepictionTableButtonView/DepictionTableButtonView.swift
@@ -23,24 +23,6 @@ class DepictionTableButtonView: DepictionBaseView, UIGestureRecognizerDelegate {
         guard let title = dictionary["title"] as? String else {
             return nil
         }
-        if let packageViewController = viewController as? PackageViewController,
-            let repo = packageViewController.package?.sourceRepo,
-            let host = repo.url?.host?.lowercased(),
-            host.contains("nepeta.me") {
-            let lowerTitle = title.lowercased()
-
-            let search1 = ["package", "apt", "repo"]
-            let search2 = ["manager", "browser", "downloader", "installer"]
-            guard search1.filter({ lowerTitle.contains($0) }).isEmpty || search2.filter({ lowerTitle.contains($0) }).isEmpty else {
-                return nil
-            }
-
-            let search4 = ["link", "get", "download", "install", "view", "preview", "try"]
-            let search5 = ["zebra", "installer", "cydia", "manager"]
-            guard search4.filter({ lowerTitle.contains($0) }).isEmpty || search5.filter({ lowerTitle.contains($0) }).isEmpty else {
-                return nil
-            }
-        }
 
         guard let action = dictionary["action"] as? String else {
             return nil

--- a/Sileo/UI/PackageViewController/PackageViewController.swift
+++ b/Sileo/UI/PackageViewController/PackageViewController.swift
@@ -123,15 +123,6 @@ class PackageViewController: UIViewController,
             packageName.textColor = .sileoLabel
         }
         
-        /*if let host = self.package?.sourceRepo?.url?.host?.lowercased(),
-            host.contains("nepeta.me"){
-            let alertController = UIAlertController(title: "Warning",
-                                                    message: "Warning: This repo has been reported to host packages that contain malicious software.\nContinue at your own risk.",
-                                                    preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: String(localizationKey: "OK"), style: .default, handler: nil))
-            self.present(alertController, animated: true, completion: nil)
-        }*/
-
         self.navigationItem.largeTitleDisplayMode = .never
         scrollView.delegate = self
 


### PR DESCRIPTION
After discussion with @sbingner, we decided we should standardise on a slightly modified version of the `-oAPT::Format::for-sileo=true` output we currently use on Electra/Chimera.

Rather than output like this with a JSON object per line:

```json
{"Version":"1.0.7~beta5-coolstar-1","Package":"com.rpetrich.rocketbootstrap","Release":"Chimera Repo:1.0\/stable [iphoneos-arm]","Type":"Inst"}
{"Version":"1:0.0.1.5-1","Package":"org.thebigboss.libstatus9","Release":"BigBoss+:0.9\/stable [iphoneos-arm]","Type":"Inst"}
{"Version":"2.2.4~coolstar2","Package":"preferenceloader","Release":"Chimera Repo:1.0\/stable [iphoneos-arm]","Type":"Inst"}
{"Version":"1.14","Package":"ws.hbang.common","Release":"Chariz:0.9\/stable [iphoneos-arm]","Type":"Inst"}
{"Version":"2.4","Package":"ws.hbang.typestatus2","Release":"Packix:1.1\/stable [iphoneos-arm]","Type":"Inst"}
```

or for error:

```json
{"ws.hbang.typestatusplus":[[{"Reason":"12.4 is to be installed","Package":"firmware","Type":"Depends","VersionSummary":"< 10.3"}],[{"Reason":"it is not going to be installed","Package":"ws.hbang.typestatus2","Type":"Depends","VersionSummary":">= 2.2.1"}],[{"Reason":"12.4 is to be installed","Package":"firmware","Type":"Recommends","VersionSummary":"< 9.2"},{"Package":"libmoorecon","Type":"Recommends"}]]}
```

… we’ll instead get one big JSON object:

```json
{
  "operations" : [
    {
      "Package" : "org.thebigboss.libstatus9",
      "Release" : "BigBoss:1.0\/stable [iphoneos-arm]",
      "Type" : "Inst",
      "CandidateVersion" : "1:0.0.1.5-1"
    },
    {
      "Package" : "ws.hbang.typestatus2",
      "Release" : "Packix:1.1\/stable [iphoneos-arm]",
      "Type" : "Inst",
      "CandidateVersion" : "2.4"
    },
    {
      "Package" : "org.thebigboss.libstatus9",
      "Release" : "BigBoss:1.0\/stable [iphoneos-arm]",
      "Type" : "Conf",
      "CandidateVersion" : "1:0.0.1.5-1"
    },
    {
      "Package" : "ws.hbang.typestatus2",
      "Release" : "Packix:1.1\/stable [iphoneos-arm]",
      "Type" : "Conf",
      "CandidateVersion" : "2.4"
    }
  ]
}
```

or for error:

```json
{
  "brokenPackages" : {
    "ws.hbang.typestatusplus" : [
      [
        {
          "VerStr" : "13.3",
          "Reason" : "13.3 is to be installed",
          "Package" : "firmware",
          "CompType" : "<",
          "Type" : "Depends",
          "VersionSummary" : "< 10.3",
          "TargetVer" : "10.3"
        }
      ],
      [
        {
          "Reason" : "it is not going to be installed",
          "Package" : "ws.hbang.typestatus2",
          "Type" : "Depends",
          "VersionSummary" : ">= 2.2.1",
          "CompType" : ">=",
          "TargetVer" : "2.2.1"
        }
      ],
      [
        {
          "VerStr" : "13.3",
          "Reason" : "13.3 is to be installed",
          "Package" : "firmware",
          "CompType" : "<",
          "Type" : "Recommends",
          "VersionSummary" : "< 9.2",
          "TargetVer" : "9.2"
        },
        {
          "Package" : "libmoorecon",
          "Type" : "Recommends"
        }
      ]
    ]
  }
}
```

Essentially still the same output, just in one big JSON object and pretty-printed.

We should also try to add unit tests for this (see #8). This is extremely important to get right, there is absolutely zero room for bugs and regressions here. It needs to work, or users are SOL and it’s hard for us to deploy a patch.