### PR TITLE
Add Norwegian Bokmål localizations to Sileo

### DIFF
--- a/Sileo/Sileo/nb.lproj/Categories.strings
+++ b/Sileo/Sileo/nb.lproj/Categories.strings
@@ -1,0 +1,21 @@
+/* 
+  Categories.strings
+  Sileo
+
+  Created by AppleBetas on 2018-12-28.
+  Copyright © 2018 CoolStar. All rights reserved.
+ 
+ BASE (English) LOCALISATIONS
+*/
+
+"No_Category" = "(No Category)";
+"Tweaks" = "Tweaks";
+"Themes" = "Themes";
+"Utilities" = "Utilities";
+"Applications" = "Applications";
+"Addons" = "Addons";
+"Games" = "Games";
+"Developer" = "Developer";
+"Data_Storage" = "Data Storage";
+"Terminal_Support" = "Terminal Support"; 
+"Text_Editors" = "Text Editors";

--- a/Sileo/Sileo/nb.lproj/Categories.strings
+++ b/Sileo/Sileo/nb.lproj/Categories.strings
@@ -3,7 +3,7 @@
   Sileo
 
   Created by AppleBetas on 2018-12-28.
-  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21).
   Copyright © 2018 CoolStar. All rights reserved.
  
  NORWEGIAN BOKMÅL LOCALISATIONS

--- a/Sileo/Sileo/nb.lproj/Categories.strings
+++ b/Sileo/Sileo/nb.lproj/Categories.strings
@@ -3,19 +3,20 @@
   Sileo
 
   Created by AppleBetas on 2018-12-28.
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
   Copyright © 2018 CoolStar. All rights reserved.
  
- BASE (English) LOCALISATIONS
+ NORWEGIAN BOKMÅL LOCALISATIONS
 */
 
-"No_Category" = "(No Category)";
+"No_Category" = "(Ingen kategori)";
 "Tweaks" = "Tweaks";
-"Themes" = "Themes";
-"Utilities" = "Utilities";
-"Applications" = "Applications";
-"Addons" = "Addons";
-"Games" = "Games";
-"Developer" = "Developer";
-"Data_Storage" = "Data Storage";
-"Terminal_Support" = "Terminal Support"; 
-"Text_Editors" = "Text Editors";
+"Themes" = "Temaer";
+"Utilities" = "Verktøy";
+"Applications" = "Applikasjoner";
+"Addons" = "Utvidelser";
+"Games" = "Spill";
+"Developer" = "Utvikler";
+"Data_Storage" = "Data lagring";
+"Terminal_Support" = "Terminalstøtte"; 
+"Text_Editors" = "Tekstredigeringsverktøy";

--- a/Sileo/Sileo/nb.lproj/Errors.strings
+++ b/Sileo/Sileo/nb.lproj/Errors.strings
@@ -1,0 +1,59 @@
+/*
+  Errors.strings
+  Sileo
+
+  Created by AppleBetas on 2018-12-28.
+  Copyright © 2018 CoolStar. All rights reserved.
+ 
+ BASE (English) LOCALISATIONS
+ */
+
+"Unknown" = "An unknown error occurred.";
+"Error_Indicator" = "Error: %@";
+
+"No_Package.Title" = "Couldn’t find the package %@ in the repositories you currently have installed.";
+"No_Package.Body" = "If it’s new, wait for Sileo to finish updating, then try again. Check online for more help.";
+
+"Invalid_URL.Title" = "Invalid URL";
+
+"Download_Size_Mismatch" = "Expected size %@, got %@ instead.";
+"Download_Failing_Status_Code" = "Failed with status %ld";
+"Download_Hash_Mismatch" = "Expected hash %@, got %@ instead.";
+"Untrusted_Package" = "Package %@ is untrusted and can not be verified";
+
+"Insecure_Paid_Download" = "Payment-authorized package download URLs must be secure (HTTPS).";
+
+"Invalid_Payment_Provider_Response" = "The payment provider issued an invalid response.";
+"No_Payment_Provider" = "This repo does not support Sileo purchases. If this is a Cydia Store package that you have already purchased, you may link your account to download it.";
+
+"Package_Unavailable" = "This package is not available from your installed sources. Please check to make sure that the %@ repo is available.";
+
+"Installation_Error.Title" = "Installation Error";
+"Installation_Error.Body" = "Sileo was unable to acquire root permissions. Please reinstall Sileo using SSH.";
+
+"FixingDpkg.Title" = "Dpkg Interrupted";
+"FixingDpkg.Body" = "Dpkg was interrupted. Please wait while we attempt to fix the issue.";
+
+"Invalid_Data" = "Invalid Data";
+"Try_Later" = "Please try again later.";
+
+"Sileo_Update_Required.Title" = "Sileo Update Required";
+"Featured_Requires_Sileo_Update" = "A Sileo update is required to view the featured tab. The featured tab may be rendered incorrectly.";
+"Depiction_Requires_Sileo_Update" = "A Sileo update is required to view this page. The page may be rendered incorrectly.";
+
+"Form_Error.Title" = "Couldn't Load Form";
+"Form_Load_Error" = "The form could not be loaded from the server.";
+"Invalid_Form_Data" = "The server provided invalid form data.";
+"Form_Submit_Failure" = "An error occurred while attempting to submit the form: %@";
+"Form_Submit_Error.Title" = "Couldn't Submit Form";
+"Form_Action_Host_Mismatch" = "The form action's URL host doesn't match the form's origin host.";
+
+"Email_Unavailable.Title" = "Cannot Send Email";
+"Email_Unavailable.Body" = "Mail services are not available.";
+
+"Settings_Payment_Provider.Profile.Title" = "Couldn't Load Profile";
+
+"Provider_Auth_Fail.Title" = "Couldn't Authenticate Provider";
+"Purchase_Initiate_Fail.Title" = "Couldn't Initiate Purchase";
+"Purchase_Complete_Fail.Title" = "Couldn't Complete Purchase";
+"Purchase_Auth_Complete_Fail.Title" = "Couldn't Complete Authentication";

--- a/Sileo/Sileo/nb.lproj/Errors.strings
+++ b/Sileo/Sileo/nb.lproj/Errors.strings
@@ -3,7 +3,7 @@
   Sileo
 
   Created by AppleBetas on 2018-12-28.
-  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21).
   Copyright © 2018 CoolStar. All rights reserved.
  
  NORWEGIAN BOKMÅL LOCALISATIONS

--- a/Sileo/Sileo/nb.lproj/Errors.strings
+++ b/Sileo/Sileo/nb.lproj/Errors.strings
@@ -3,57 +3,58 @@
   Sileo
 
   Created by AppleBetas on 2018-12-28.
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
   Copyright © 2018 CoolStar. All rights reserved.
  
- BASE (English) LOCALISATIONS
+ NORWEGIAN BOKMÅL LOCALISATIONS
  */
 
-"Unknown" = "An unknown error occurred.";
-"Error_Indicator" = "Error: %@";
+"Unknown" = "En ukjent feil oppstod.";
+"Error_Indicator" = "Feil: %@";
 
-"No_Package.Title" = "Couldn’t find the package %@ in the repositories you currently have installed.";
-"No_Package.Body" = "If it’s new, wait for Sileo to finish updating, then try again. Check online for more help.";
+"No_Package.Title" = "Kunne ikke finne pakken %@ i kildene du har lagt til.";
+"No_Package.Body" = "Hvis den er ny, vennligst vent til Sileo er ferdig med å oppdatere, og prøv igjen. Sjekk på nett for mer hjelp.";
 
-"Invalid_URL.Title" = "Invalid URL";
+"Invalid_URL.Title" = "Ugyldig URL";
 
-"Download_Size_Mismatch" = "Expected size %@, got %@ instead.";
-"Download_Failing_Status_Code" = "Failed with status %ld";
-"Download_Hash_Mismatch" = "Expected hash %@, got %@ instead.";
-"Untrusted_Package" = "Package %@ is untrusted and can not be verified";
+"Download_Size_Mismatch" = "Forventet størrelse %@, fikk %@ istedenfor.";
+"Download_Failing_Status_Code" = "Feilet med status %ld";
+"Download_Hash_Mismatch" = "Forventet nøkkel %@, fikk %@ istedenfor.";
+"Untrusted_Package" = "Pakke %@ er ikke verifisert og kan ikke bekreftes.";
 
-"Insecure_Paid_Download" = "Payment-authorized package download URLs must be secure (HTTPS).";
+"Insecure_Paid_Download" = "Betalingsautoriserte-nedlastingsadresser for pakker må være sikre (HTTPS).";
 
-"Invalid_Payment_Provider_Response" = "The payment provider issued an invalid response.";
-"No_Payment_Provider" = "This repo does not support Sileo purchases. If this is a Cydia Store package that you have already purchased, you may link your account to download it.";
+"Invalid_Payment_Provider_Response" = "Betalingsleverandøren ga et ugyldig svar.";
+"No_Payment_Provider" = "Denne kilden støtter ikke Sileo-kjøp. Hvis dette er en Cydia Store-pakke som du allerede har kjøpt, kan du logge inn på kontoen din for å laste den ned.";
 
-"Package_Unavailable" = "This package is not available from your installed sources. Please check to make sure that the %@ repo is available.";
+"Package_Unavailable" = "Denne pakken er ikke tilgjengelig fra dine kilder. Kontroller at kilden %@ er tilgjengelig.";
 
-"Installation_Error.Title" = "Installation Error";
-"Installation_Error.Body" = "Sileo was unable to acquire root permissions. Please reinstall Sileo using SSH.";
+"Installation_Error.Title" = "Installasjonsfeil";
+"Installation_Error.Body" = "Sileo klarte ikke å skaffe rotrettigheter. Vennligst installer Sileo på nytt ved å bruke SSH.";
 
-"FixingDpkg.Title" = "Dpkg Interrupted";
-"FixingDpkg.Body" = "Dpkg was interrupted. Please wait while we attempt to fix the issue.";
+"FixingDpkg.Title" = "Dpkg avbrutt";
+"FixingDpkg.Body" = "Dpkg ble avbrutt. Vennligst vent mens vi prøver å løse problemet.";
 
-"Invalid_Data" = "Invalid Data";
-"Try_Later" = "Please try again later.";
+"Invalid_Data" = "Ugyldig Data";
+"Try_Later" = "Vennligst prøv igjen senere.";
 
-"Sileo_Update_Required.Title" = "Sileo Update Required";
-"Featured_Requires_Sileo_Update" = "A Sileo update is required to view the featured tab. The featured tab may be rendered incorrectly.";
-"Depiction_Requires_Sileo_Update" = "A Sileo update is required to view this page. The page may be rendered incorrectly.";
+"Sileo_Update_Required.Title" = "Sileo oppdatering kreves";
+"Featured_Requires_Sileo_Update" = "En Sileo oppdatering er nødvendig for å se fanen med utvalgte pakker. Fanen som nå vises, kan gjengis feil.";
+"Depiction_Requires_Sileo_Update" = "En Sileo oppdatering er nødvendig for å se denne siden. Siden kan gjengis feil.";
 
-"Form_Error.Title" = "Couldn't Load Form";
-"Form_Load_Error" = "The form could not be loaded from the server.";
-"Invalid_Form_Data" = "The server provided invalid form data.";
-"Form_Submit_Failure" = "An error occurred while attempting to submit the form: %@";
-"Form_Submit_Error.Title" = "Couldn't Submit Form";
-"Form_Action_Host_Mismatch" = "The form action's URL host doesn't match the form's origin host.";
+"Form_Error.Title" = "Kunne ikke laste inn skjemaet";
+"Form_Load_Error" = "Skjemaet kunne ikke lastes inn fra serveren.";
+"Invalid_Form_Data" = "Serveren ga ugyldig skjemadata.";
+"Form_Submit_Failure" = "Det oppstod en feil under forsøk på å sende inn skjemaet: %@";
+"Form_Submit_Error.Title" = "Kunne ikke sende inn skjema";
+"Form_Action_Host_Mismatch" = "URL-verten for skjemahandlingene samsvarer ikke med skjemaets opprinnelsesvert.";
 
-"Email_Unavailable.Title" = "Cannot Send Email";
-"Email_Unavailable.Body" = "Mail services are not available.";
+"Email_Unavailable.Title" = "Kan ikke sende e-post";
+"Email_Unavailable.Body" = "e-posttjenester er ikke tilgjengelige.";
 
-"Settings_Payment_Provider.Profile.Title" = "Couldn't Load Profile";
+"Settings_Payment_Provider.Profile.Title" = "Kunne ikke laste inn profil";
 
-"Provider_Auth_Fail.Title" = "Couldn't Authenticate Provider";
-"Purchase_Initiate_Fail.Title" = "Couldn't Initiate Purchase";
-"Purchase_Complete_Fail.Title" = "Couldn't Complete Purchase";
-"Purchase_Auth_Complete_Fail.Title" = "Couldn't Complete Authentication";
+"Provider_Auth_Fail.Title" = "Kunne ikke autentisere leverandøren";
+"Purchase_Initiate_Fail.Title" = "Kunne ikke starte kjøp";
+"Purchase_Complete_Fail.Title" = "Kunne ikke fullføre kjøpet";
+"Purchase_Auth_Complete_Fail.Title" = "Kunne ikke fullføre autentiseringen";

--- a/Sileo/Sileo/nb.lproj/Localizable.strings
+++ b/Sileo/Sileo/nb.lproj/Localizable.strings
@@ -1,0 +1,157 @@
+/* 
+  Localizable.strings
+  Sileo
+
+  Created by AppleBetas on 2018-12-27.
+  Copyright © 2018 CoolStar. All rights reserved.
+ 
+ BASE (English) LOCALISATIONS
+*/
+
+// Credit Information (optional, uncomment to specify)
+//"__LocalizationCredit.Title" = "English translation by AppleBetas";
+//"__LocalizationCredit.URL" = "https://www.twitter.com/AppleBetasDev"; // (optional)
+
+// Common Prompts
+"About" = "About";
+"Close" = "Close";
+"Double tap to open." = "Double tap to open.";
+"Untitled_Repo" = "Untitled Repo";
+"OK" = "OK";
+"Done" = "Done";
+"Done_Editing" = "Done";
+"More_Info" = "More Info";
+"Loading" = "Loading…";
+"Share" = "Share";
+"Delete" = "Delete";
+"Cancel" = "Cancel";
+
+// Statuses for queued/downloading packages. Shown under their name in the queue/status popup.
+"Installing_Package_Status" = "Installing";
+"Downloading_Package_Status" = "Downloading";
+"Queued_Package_Status" = "Queued";
+"Ready_Status" = "Ready";
+"Removal_Queued_Package_Status" = "Queued for Removal";
+"Download_Starting" = "Starting…";
+"Download_Progress" = "%@ of %@"; // first %@ = amount downloaded, second %@ = total to download
+
+"Queue_Confirm_Button" = "Confirm";
+"Queue_Clear_Button" = "Clear Queue";
+
+"Package_Upgrade_Action" = "Upgrade";
+"Package_Reinstall_Action" = "Reinstall";
+"Package_Uninstall_Action" = "Uninstall";
+"Package_Modify_Action" = "Modify";
+"Package_Get_Action" = "Get";
+"Package_Queue_Action" = "Queue";
+"Package_Cancel_Action" = "Cancel";
+
+"Package_Share_Action" = "Share Package…";
+"Package_Developer_Find_Action" = "More by this Developer";
+"Package_Support_Action" = "Support";
+"Package_Hold_Enable_Action" = "Ignore Future Updates";
+"Package_Hold_Disable_Action" = "Stop Ignoring Updates";
+"Package_Wishlist_Add" = "Add to Wishlist";
+"Package_Wishlist_Remove" = "Remove from Wishlist";
+"Wishlist" = "Wishlist";
+
+// Headings for sections in the queue/status popup.
+"Queued_Install_Heading" = "Install";
+"Queued_Uninstall_Heading" = "Uninstall";
+"Queued_Update_Heading" = "Update";
+"Download_Errors_Heading" = "Errors";
+
+"Installed_Heading" = "Installed";
+"Updates_Heading" = "Updates";
+"Upgrade_All_Button" = "Upgrade All";
+"Package_Search.Placeholder" = "Search for Packages";
+"Sort_Name" = "Name";
+"Sort_Date" = "Date";
+"Sort_By" = "Sort by:";
+
+"Package_Unavailable" = "Package Unavailable";
+"Package_By_Author" = "%@ by %@"; // first %@ = package name, second %@ = author name
+"By_Author" = "by %@"; // %@ = author name
+"Packages_By_Author" = "Packages by %@"; // %@ = author name
+
+"Featured_Page" = "Featured";
+"News_Page" = "New";
+"Sources_Page" = "Sources";
+"Packages_Page" = "Packages";
+"Search_Page" = "Search";
+"Refreshing_Sources_Page" = "Refreshing Sources";
+"Package_Installed_Files_Page" = "Installed Files";
+
+"All_Packages.Title" = "All Packages";
+"All_Packages.Cell_Subtitle" = "See all packages from your sources";
+
+"All_Categories" = "All Categories";
+
+"Repos" = "Repositories";
+
+"Add_Source.Title" = "Add Source";
+"Add_Source.Body" = "Add APT URL";
+"Add_Source.Button.Add" = "Add Source";
+
+"Auto_Add_Pasteboard_Sources.Button.Manual" = "Enter Manually";
+
+"Untitled_Form" = "Untitled Form";
+"Form_Submitted.Default_Title" = "Submitted Form";
+"Form_Submitted.Default_Body" = "The form was submitted successfully.";
+
+"Web_Depiction_Deprecated_Warning" = "Web View depictions are deprecated. Please contact the repo maintainer about updating to native depictions.";
+
+"Package_Details_Tab" = "Details";
+"Package_Changelog_Tab" = "Changelog";
+"Package_No_Description_Available" = "No description is available for this package.";
+"Package_Changelogs_Unavailable" = "Changelogs are not available for this package.";
+
+"Installed_Package_Header" = "Installed Package";
+"Version" = "Version";
+"Show_Package_Contents_Button" = "Show Package Contents";
+
+"Licenses_Page_Title" = "Licenses";
+
+"Settings_Payment_Provider_Heading" = "Payment Providers";
+"Settings_Translations_Heading" = "Translations";
+
+"Settings_Payment_Provider.Purchases_Heading" = "Purchases";
+"Settings_Payment_Provider.No_Purchases" = "No purchases";
+
+"Settings" = "Settings";
+"Settings_Page_Title" = "Settings";
+"Dark_Mode_Toggle" = "Dark Mode";
+
+"Cydia_Sign_In" = "Sign in to Cydia Store";
+"Payment_Provider_Signed_In" = "Signed in";
+"Payment_Provider_Signed_In_With_Name" = "Signed in as %@"; // %@ = user's name
+"Payment_Provider_Sign_Out" = "Sign out";
+"Payment_Provider_Sign_Out_Confirm.Title" = "Sign out of %@"; // %@ = payment provider name
+"Payment_Provider_Sign_Out_Confirm.Body" = "You will no longer be able to download your purchased packages until you sign back in.";
+
+"Package_Filter_User" = "User";
+"Package_Filter_PowerUser" = "Power User";
+"Package_Filter_Dev" = "Developer";
+
+"Show_Install_Details" = "Show Details";
+"Hide_Install_Details" = "Hide Details";
+
+"After_Install_Relaunch" = "Restart Sileo";
+"After_Install_Respring" = "Restart SpringBoard";
+"After_Install_Reboot" = "Reboot Device";
+
+"Dangerous_Repo.Title" = "Dangerous Repo";
+"Dangerous_Repo.Body" = "You are attempting to add a repository that is known to be harmful for reasons such as piracy, illegal content, or malware.\n\nRepositories marked as harmful often distribute software with unexpected effects, whether in the form of paid packages for free or other malicious packages. This can have lasting effects on your device and privacy, even sometimes affecting your ability to jailbreak. We recommend that you exercise extreme caution to avoid harmful software.";
+"Dangerous_Repo.Continue" = "I accept the risks, continue";
+"Dangerous_Repo.Cancel" = "Take me back to safety";
+"Dangerous_Repo.Last_Chance.Title" = "Add Harmful Repo?";
+"Dangerous_Repo.Last_Chance.Body" = "Dangerous repositories can have devastating effects on your ability to use your device or jailbreak. We strongly recommend that you go back for your own safety.";
+"Dangerous_Repo.Last_Chance.Continue" = "Continue";
+"Dangerous_Repo.Last_Chance.Cancel" = "Go back";
+
+// All export-based strings
+"Export" = "Export";
+"Export_Packages" = "Would you like to export your packages list? This will copy all package names and their versions to your clipboard.";
+"Export_Sources" = "Would you like to export your source list? This will copy all source URLs to your clipboard.";
+"Export_Yes" = "Yes, copy.";
+"Export_No" = "No, cancel.";

--- a/Sileo/Sileo/nb.lproj/Localizable.strings
+++ b/Sileo/Sileo/nb.lproj/Localizable.strings
@@ -10,8 +10,8 @@
 */
 
 // Credit Information (optional, uncomment to specify)
-//"__LocalizationCredit.Title" = "Sileo oversatt til Norsk Bokmål av WorldlyDev";
-//"__LocalizationCredit.URL" = "https://twitter.com/worldlydev"; // (optional)
+"__LocalizationCredit.Title" = "Sileo oversatt til Norsk Bokmål av WorldlyDev";
+"__LocalizationCredit.URL" = "https://twitter.com/worldlydev"; // (optional)
 
 // Common Prompts
 "About" = "Om";

--- a/Sileo/Sileo/nb.lproj/Localizable.strings
+++ b/Sileo/Sileo/nb.lproj/Localizable.strings
@@ -3,7 +3,7 @@
   Sileo
 
   Created by AppleBetas on 2018-12-27.
-  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21).
   Copyright © 2018 CoolStar. All rights reserved.
  
  NORWEGIAN BOKMÅL LOCALISATIONS

--- a/Sileo/Sileo/nb.lproj/Localizable.strings
+++ b/Sileo/Sileo/nb.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 
 // Credit Information (optional, uncomment to specify)
 //"__LocalizationCredit.Title" = "Sileo oversatt til Norsk Bokmål av WorldlyDev";
-//"__LocalizationCredit.URL" = "https://github.com/worldlydev"; // (optional)
+//"__LocalizationCredit.URL" = "https://twitter.com/worldlydev"; // (optional)
 
 // Common Prompts
 "About" = "Om";

--- a/Sileo/Sileo/nb.lproj/Localizable.strings
+++ b/Sileo/Sileo/nb.lproj/Localizable.strings
@@ -3,155 +3,156 @@
   Sileo
 
   Created by AppleBetas on 2018-12-27.
+  Translated to Norwegian Bokmål by : WorldlyDev (2020-04-21) 
   Copyright © 2018 CoolStar. All rights reserved.
  
- BASE (English) LOCALISATIONS
+ NORWEGIAN BOKMÅL LOCALISATIONS
 */
 
 // Credit Information (optional, uncomment to specify)
-//"__LocalizationCredit.Title" = "English translation by AppleBetas";
-//"__LocalizationCredit.URL" = "https://www.twitter.com/AppleBetasDev"; // (optional)
+//"__LocalizationCredit.Title" = "Sileo oversatt til Norsk Bokmål av WorldlyDev";
+//"__LocalizationCredit.URL" = "https://github.com/worldlydev"; // (optional)
 
 // Common Prompts
-"About" = "About";
-"Close" = "Close";
-"Double tap to open." = "Double tap to open.";
-"Untitled_Repo" = "Untitled Repo";
-"OK" = "OK";
-"Done" = "Done";
-"Done_Editing" = "Done";
-"More_Info" = "More Info";
-"Loading" = "Loading…";
-"Share" = "Share";
-"Delete" = "Delete";
-"Cancel" = "Cancel";
+"About" = "Om";
+"Close" = "Lukk";
+"Double tap to open." = "Dobbelttrykk for å åpne.";
+"Untitled_Repo" = "Navnløs kilde";
+"OK" = "Ok";
+"Done" = "Ferdig";
+"Done_Editing" = "Ferdig";
+"More_Info" = "Mer info";
+"Loading" = "Laster…";
+"Share" = "Del";
+"Delete" = "Slett";
+"Cancel" = "Kanseller";
 
 // Statuses for queued/downloading packages. Shown under their name in the queue/status popup.
-"Installing_Package_Status" = "Installing";
-"Downloading_Package_Status" = "Downloading";
-"Queued_Package_Status" = "Queued";
-"Ready_Status" = "Ready";
-"Removal_Queued_Package_Status" = "Queued for Removal";
-"Download_Starting" = "Starting…";
-"Download_Progress" = "%@ of %@"; // first %@ = amount downloaded, second %@ = total to download
+"Installing_Package_Status" = "Installerer";
+"Downloading_Package_Status" = "Laster ned";
+"Queued_Package_Status" = "Lagt til i køen";
+"Ready_Status" = "Klar";
+"Removal_Queued_Package_Status" = "Lagt til i køen for fjerning";
+"Download_Starting" = "Starter…";
+"Download_Progress" = "%@ av %@"; // first %@ = amount downloaded, second %@ = total to download
 
-"Queue_Confirm_Button" = "Confirm";
-"Queue_Clear_Button" = "Clear Queue";
+"Queue_Confirm_Button" = "Bekreft";
+"Queue_Clear_Button" = "Tøm kø";
 
-"Package_Upgrade_Action" = "Upgrade";
-"Package_Reinstall_Action" = "Reinstall";
-"Package_Uninstall_Action" = "Uninstall";
-"Package_Modify_Action" = "Modify";
-"Package_Get_Action" = "Get";
-"Package_Queue_Action" = "Queue";
-"Package_Cancel_Action" = "Cancel";
+"Package_Upgrade_Action" = "Oppgrader";
+"Package_Reinstall_Action" = "Installer på nytt";
+"Package_Uninstall_Action" = "Avinstaller";
+"Package_Modify_Action" = "Endre";
+"Package_Get_Action" = "Hent";
+"Package_Queue_Action" = "Kø";
+"Package_Cancel_Action" = "Kanseller";
 
-"Package_Share_Action" = "Share Package…";
-"Package_Developer_Find_Action" = "More by this Developer";
-"Package_Support_Action" = "Support";
-"Package_Hold_Enable_Action" = "Ignore Future Updates";
-"Package_Hold_Disable_Action" = "Stop Ignoring Updates";
-"Package_Wishlist_Add" = "Add to Wishlist";
-"Package_Wishlist_Remove" = "Remove from Wishlist";
-"Wishlist" = "Wishlist";
+"Package_Share_Action" = "Del pakke…";
+"Package_Developer_Find_Action" = "Mer fra denne utvikleren";
+"Package_Support_Action" = "Støtte";
+"Package_Hold_Enable_Action" = "Ignorer fremtidige oppdateringer";
+"Package_Hold_Disable_Action" = "Slutt å ignorere oppdateringer";
+"Package_Wishlist_Add" = "Legg til i ønskelisten";
+"Package_Wishlist_Remove" = "Fjern fra ønskelisten";
+"Wishlist" = "Ønskeliste";
 
 // Headings for sections in the queue/status popup.
-"Queued_Install_Heading" = "Install";
-"Queued_Uninstall_Heading" = "Uninstall";
-"Queued_Update_Heading" = "Update";
-"Download_Errors_Heading" = "Errors";
+"Queued_Install_Heading" = "Installer";
+"Queued_Uninstall_Heading" = "Avinstaller";
+"Queued_Update_Heading" = "Oppdater";
+"Download_Errors_Heading" = "Feil";
 
-"Installed_Heading" = "Installed";
-"Updates_Heading" = "Updates";
-"Upgrade_All_Button" = "Upgrade All";
-"Package_Search.Placeholder" = "Search for Packages";
-"Sort_Name" = "Name";
-"Sort_Date" = "Date";
-"Sort_By" = "Sort by:";
+"Installed_Heading" = "Installert";
+"Updates_Heading" = "Oppdateringer";
+"Upgrade_All_Button" = "Oppdater alle";
+"Package_Search.Placeholder" = "Søk etter pakker";
+"Sort_Name" = "Navn";
+"Sort_Date" = "Dato";
+"Sort_By" = "Sorter etter:";
 
-"Package_Unavailable" = "Package Unavailable";
-"Package_By_Author" = "%@ by %@"; // first %@ = package name, second %@ = author name
-"By_Author" = "by %@"; // %@ = author name
-"Packages_By_Author" = "Packages by %@"; // %@ = author name
+"Package_Unavailable" = "Pakke utilgjengelig";
+"Package_By_Author" = "%@ av %@"; // first %@ = package name, second %@ = author name
+"By_Author" = "av %@"; // %@ = author name
+"Packages_By_Author" = "Pakker av %@"; // %@ = author name
 
-"Featured_Page" = "Featured";
-"News_Page" = "New";
-"Sources_Page" = "Sources";
-"Packages_Page" = "Packages";
-"Search_Page" = "Search";
-"Refreshing_Sources_Page" = "Refreshing Sources";
-"Package_Installed_Files_Page" = "Installed Files";
+"Featured_Page" = "Utvalgt";
+"News_Page" = "Ny";
+"Sources_Page" = "Kilder";
+"Packages_Page" = "Pakker";
+"Search_Page" = "Søk";
+"Refreshing_Sources_Page" = "Oppdaterer kilder";
+"Package_Installed_Files_Page" = "Installerte filer";
 
-"All_Packages.Title" = "All Packages";
-"All_Packages.Cell_Subtitle" = "See all packages from your sources";
+"All_Packages.Title" = "Alle pakker";
+"All_Packages.Cell_Subtitle" = "Se alle pakkene fra kildene dine";
 
-"All_Categories" = "All Categories";
+"All_Categories" = "Alle kategorier";
 
-"Repos" = "Repositories";
+"Repos" = "Kilder";
 
-"Add_Source.Title" = "Add Source";
-"Add_Source.Body" = "Add APT URL";
-"Add_Source.Button.Add" = "Add Source";
+"Add_Source.Title" = "Legg til kilde";
+"Add_Source.Body" = "Legg til APT-nettadresse";
+"Add_Source.Button.Add" = "Legg til kilde";
 
-"Auto_Add_Pasteboard_Sources.Button.Manual" = "Enter Manually";
+"Auto_Add_Pasteboard_Sources.Button.Manual" = "Legg til manuelt";
 
-"Untitled_Form" = "Untitled Form";
-"Form_Submitted.Default_Title" = "Submitted Form";
-"Form_Submitted.Default_Body" = "The form was submitted successfully.";
+"Untitled_Form" = "Navnløs skjema";
+"Form_Submitted.Default_Title" = "Innsendt skejma";
+"Form_Submitted.Default_Body" = "Innsending av skjemaet var vellykket.";
 
-"Web_Depiction_Deprecated_Warning" = "Web View depictions are deprecated. Please contact the repo maintainer about updating to native depictions.";
+"Web_Depiction_Deprecated_Warning" = "Web View-avbildninger er avviklede. Ta kontakt med kildevedlikeholderen om oppdatering til native-avbildninger.";
 
-"Package_Details_Tab" = "Details";
-"Package_Changelog_Tab" = "Changelog";
-"Package_No_Description_Available" = "No description is available for this package.";
-"Package_Changelogs_Unavailable" = "Changelogs are not available for this package.";
+"Package_Details_Tab" = "Detaljer";
+"Package_Changelog_Tab" = "Endringslogg";
+"Package_No_Description_Available" = "Ingen beskrivelse er tilgjengelig for denne pakken.";
+"Package_Changelogs_Unavailable" = "Endringsloggen er ikke tilgjengelig for denne pakken.";
 
-"Installed_Package_Header" = "Installed Package";
-"Version" = "Version";
-"Show_Package_Contents_Button" = "Show Package Contents";
+"Installed_Package_Header" = "Installert pakke";
+"Version" = "Versjon";
+"Show_Package_Contents_Button" = "Vis pakkeinnhold";
 
-"Licenses_Page_Title" = "Licenses";
+"Licenses_Page_Title" = "Lisenser";
 
-"Settings_Payment_Provider_Heading" = "Payment Providers";
-"Settings_Translations_Heading" = "Translations";
+"Settings_Payment_Provider_Heading" = "Betalingsleverandører";
+"Settings_Translations_Heading" = "Oversettelser";
 
-"Settings_Payment_Provider.Purchases_Heading" = "Purchases";
-"Settings_Payment_Provider.No_Purchases" = "No purchases";
+"Settings_Payment_Provider.Purchases_Heading" = "Kjøp";
+"Settings_Payment_Provider.No_Purchases" = "Ingen kjøp";
 
-"Settings" = "Settings";
-"Settings_Page_Title" = "Settings";
-"Dark_Mode_Toggle" = "Dark Mode";
+"Settings" = "Innstillinger";
+"Settings_Page_Title" = "Innstillinger";
+"Dark_Mode_Toggle" = "Mørk modus";
 
-"Cydia_Sign_In" = "Sign in to Cydia Store";
-"Payment_Provider_Signed_In" = "Signed in";
-"Payment_Provider_Signed_In_With_Name" = "Signed in as %@"; // %@ = user's name
-"Payment_Provider_Sign_Out" = "Sign out";
-"Payment_Provider_Sign_Out_Confirm.Title" = "Sign out of %@"; // %@ = payment provider name
-"Payment_Provider_Sign_Out_Confirm.Body" = "You will no longer be able to download your purchased packages until you sign back in.";
+"Cydia_Sign_In" = "Logg på Cydia Store";
+"Payment_Provider_Signed_In" = "Innlogget";
+"Payment_Provider_Signed_In_With_Name" = "Innlogget som %@"; // %@ = user's name
+"Payment_Provider_Sign_Out" = "Logg ut";
+"Payment_Provider_Sign_Out_Confirm.Title" = "Logg ut av %@"; // %@ = payment provider name
+"Payment_Provider_Sign_Out_Confirm.Body" = "Du vil ikke lenger kunne laste ned kjøpte pakker før du logger deg på igjen.";
 
-"Package_Filter_User" = "User";
-"Package_Filter_PowerUser" = "Power User";
-"Package_Filter_Dev" = "Developer";
+"Package_Filter_User" = "Bruker";
+"Package_Filter_PowerUser" = "Avansert bruker";
+"Package_Filter_Dev" = "Utvikler";
 
-"Show_Install_Details" = "Show Details";
-"Hide_Install_Details" = "Hide Details";
+"Show_Install_Details" = "Vis detaljer";
+"Hide_Install_Details" = "Skjul detaljer";
 
-"After_Install_Relaunch" = "Restart Sileo";
-"After_Install_Respring" = "Restart SpringBoard";
-"After_Install_Reboot" = "Reboot Device";
+"After_Install_Relaunch" = "Start Sileo på nytt";
+"After_Install_Respring" = "Start SpringBoard på nytt";
+"After_Install_Reboot" = "Omstart enheten";
 
-"Dangerous_Repo.Title" = "Dangerous Repo";
-"Dangerous_Repo.Body" = "You are attempting to add a repository that is known to be harmful for reasons such as piracy, illegal content, or malware.\n\nRepositories marked as harmful often distribute software with unexpected effects, whether in the form of paid packages for free or other malicious packages. This can have lasting effects on your device and privacy, even sometimes affecting your ability to jailbreak. We recommend that you exercise extreme caution to avoid harmful software.";
-"Dangerous_Repo.Continue" = "I accept the risks, continue";
-"Dangerous_Repo.Cancel" = "Take me back to safety";
-"Dangerous_Repo.Last_Chance.Title" = "Add Harmful Repo?";
-"Dangerous_Repo.Last_Chance.Body" = "Dangerous repositories can have devastating effects on your ability to use your device or jailbreak. We strongly recommend that you go back for your own safety.";
-"Dangerous_Repo.Last_Chance.Continue" = "Continue";
-"Dangerous_Repo.Last_Chance.Cancel" = "Go back";
+"Dangerous_Repo.Title" = "Farlig kilde";
+"Dangerous_Repo.Body" = "Du forsøker å legge til en kilde som er kjent for å være skadelig blant annet for piratkopiering, ulovlig innhold eller skadelig programvare.\n\nKilder merket som skadelig distribuerer ofte programvare med uforventede effekter, enten i form av piratkopierte betalte pakker eller andre ondsinnede pakker. Dette kan ha varige effekter på enheten din og personvernet ditt, og kan påvirke evnen din til en fremtidig jailbreak. Vi anbefaler derfor at du bruker ekstrem varsomhet for å unngå skadelig programvare.";
+"Dangerous_Repo.Continue" = "Jeg aksepterer risikoen, fortsett";
+"Dangerous_Repo.Cancel" = "Unngå farlig kilde";
+"Dangerous_Repo.Last_Chance.Title" = "Legg til farlig kilde?";
+"Dangerous_Repo.Last_Chance.Body" = "Farlige kilder kan ha ødeleggende effekter på evnen til å bruke enheten din eller en fremtidig jailbreak. Vi anbefaler på det sterkeste at du ikke legger til kilden for din egen sikkerhet.";
+"Dangerous_Repo.Last_Chance.Continue" = "Fortsett";
+"Dangerous_Repo.Last_Chance.Cancel" = "Kanseller";
 
 // All export-based strings
-"Export" = "Export";
-"Export_Packages" = "Would you like to export your packages list? This will copy all package names and their versions to your clipboard.";
-"Export_Sources" = "Would you like to export your source list? This will copy all source URLs to your clipboard.";
-"Export_Yes" = "Yes, copy.";
-"Export_No" = "No, cancel.";
+"Export" = "Eksporter";
+"Export_Packages" = "Vil du eksportere pakkelisten din? Dette vil kopiere navnene til alle pakkene dine og deres versjoner til utklippstavlen.";
+"Export_Sources" = "Vil du eksportere kildelisten din? Dette vil kopiere alle kildeadresser til utklippstavlen.";
+"Export_Yes" = "Ja, kopier.";
+"Export_No" = "Nei, kanseller.";

--- a/Sileo/Sileo/nb.lproj/Localizable.stringsdict
+++ b/Sileo/Sileo/nb.lproj/Localizable.stringsdict
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Auto_Add_Pasteboard_Sources.Title</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Automatically Add %#@sources@</string>
+		<key>sources</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lu</string>
+			<key>one</key>
+			<string>Source</string>
+			<key>other</key>
+			<string>Sources</string>
+		</dict>
+	</dict>
+	<key>Auto_Add_Pasteboard_Sources.Button.Add</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Add %lu %#@sources@</string>
+		<key>sources</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lu</string>
+			<key>one</key>
+			<string>Source</string>
+			<key>other</key>
+			<string>Sources</string>
+		</dict>
+	</dict>
+	<key>Auto_Add_Pasteboard_Sources.Body_Intro</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Add the following %#@urls@ found on your pasteboard:</string>
+		<key>urls</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lu</string>
+			<key>one</key>
+			<string>URL</string>
+			<key>other</key>
+			<string>URLs</string>
+		</dict>
+	</dict>
+	<key>Package_Queue_Count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@packages@</string>
+		<key>packages</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>No Packages</string>
+			<key>one</key>
+			<string>%d Package</string>
+			<key>other</key>
+			<string>%d Packages</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sileo/Sileo/nb.lproj/Localizable.stringsdict
+++ b/Sileo/Sileo/nb.lproj/Localizable.stringsdict
@@ -5,7 +5,7 @@
 	<key>Auto_Add_Pasteboard_Sources.Title</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Automatically Add %#@sources@</string>
+		<string>Legg til %#@sources@ automatisk</string>
 		<key>sources</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -13,15 +13,15 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lu</string>
 			<key>one</key>
-			<string>Source</string>
+			<string>Kilde</string>
 			<key>other</key>
-			<string>Sources</string>
+			<string>Kilder</string>
 		</dict>
 	</dict>
 	<key>Auto_Add_Pasteboard_Sources.Button.Add</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Add %lu %#@sources@</string>
+		<string>Legg til %lu %#@sources@</string>
 		<key>sources</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,15 +29,15 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lu</string>
 			<key>one</key>
-			<string>Source</string>
+			<string>Kilde</string>
 			<key>other</key>
-			<string>Sources</string>
+			<string>Kilder</string>
 		</dict>
 	</dict>
 	<key>Auto_Add_Pasteboard_Sources.Body_Intro</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Add the following %#@urls@ found on your pasteboard:</string>
+		<string>Legg til følgende %#@urls@ funnet i utklippstavlen din:</string>
 		<key>urls</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -45,9 +45,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lu</string>
 			<key>one</key>
-			<string>URL</string>
+			<string>Nettadresse</string>
 			<key>other</key>
-			<string>URLs</string>
+			<string>Nettadresser</string>
 		</dict>
 	</dict>
 	<key>Package_Queue_Count</key>
@@ -61,11 +61,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>zero</key>
-			<string>No Packages</string>
+			<string>Ingen pakker</string>
 			<key>one</key>
-			<string>%d Package</string>
+			<string>%d pakke</string>
 			<key>other</key>
-			<string>%d Packages</string>
+			<string>%d pakker</string>
 		</dict>
 	</dict>
 </dict>

--- a/Sileo/Sileo/nb.lproj/Localizable.stringsdict
+++ b/Sileo/Sileo/nb.lproj/Localizable.stringsdict
@@ -37,7 +37,7 @@
 	<key>Auto_Add_Pasteboard_Sources.Body_Intro</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Legg til følgende %#@urls@ funnet i utklippstavlen din:</string>
+		<string>Legg til følgende %#@urls@ fra utklippstavlen din:</string>
 		<key>urls</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>


### PR DESCRIPTION
Not sure if I did this correctly but all my translations are included in this PR.

Suggestion:

- Perhaps use Crowdin to handle localizations now that Sileo is open-source? Makes it super easy to update strings for non-GitHub oriented people like me ;) I could open a GitHub issue for it if the team is at all open to that.

Question:

- If I were to translate to Norwegian Nynorsk as well would I name the lproj: nn.lproj or nn-NO.lproj?