### PR TITLE
Change linkings from coolstar/Sileo.git to Sileo/Sileo.git

### DIFF
--- a/Onboarding.md
+++ b/Onboarding.md
@@ -5,7 +5,7 @@ To get started with developing Sileo you must follow a few extra steps rather th
 First start by running:
 
 ```
-git clone --recursive https://github.com/coolstar/SileoApp.git
+git clone --recursive https://github.com/Sileo/Sileo.git
 ```
 
 Once you do this continue by installing the Cocoapods we use:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Sileo is made with love, not just in California, but by people from all over the
 
 ## Contributing
 
-If you want to contribute to the project, make a pull request with your changes and it will be reviewed by our team. Do not contact individual people personally in order to get your changes through because that will not work. Refer to [Onboarding](https://github.com/coolstar/SileoApp/blob/master/Onboarding.md)
+If you want to contribute to the project, make a pull request with your changes and it will be reviewed by our team. Do not contact individual people personally in order to get your changes through because that will not work. Refer to [Onboarding](https://github.com/Sileo/Sileo/blob/master/Onboarding.md)
 
 ## Updates
 


### PR DESCRIPTION
Onboarding Documentation change to start with 
`git clone --recursive https://github.com/Sileo/Sileo.git` instead,
and Redirect README Onboarding to `https://github.com/Sileo/Sileo/blob/master/Onboarding.md` instead.