### PR TITLE
Don't add modmyi or zodttd repos as repoproxy has them covered.

### DIFF
--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -128,10 +128,10 @@ final class RepoManager {
     func addRepos(with urls: [URL]) {
         for url in urls {
             guard !hasRepo(with: url),
-                url.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
-                url.host?.localizedCaseInsensitiveContains("apt.modmyi.com") == false,
-                url.host?.localizedCaseInsensitiveContains("cydia.zodttd.com") == false,
-                url.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false else { continue }
+                url.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false, //shouldn't need to ever add this manually
+                url.host?.localizedCaseInsensitiveContains("apt.modmyi.com") == false, //See: https://github.com/Sileo/Sileo/pull/26
+                url.host?.localizedCaseInsensitiveContains("cydia.zodttd.com") == false, //See: https://github.com/Sileo/Sileo/pull/26
+                url.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false else { continue } //Replaced by repo.chariz.com
 
             repoListLock.wait()
             let repo = Repo()
@@ -187,13 +187,13 @@ final class RepoManager {
         for repoURL in uris {
             if FileManager.default.fileExists(atPath: "/etc/apt/sources.list.d/chimera.sources") ||
                 FileManager.default.fileExists(atPath: "/etc/apt/sources.list.d/electra.list") {
-                guard !repoURL.localizedCaseInsensitiveContains("apt.bingner.com") else {
+                guard !repoURL.localizedCaseInsensitiveContains("apt.bingner.com") else { //can cause problems on electra/chimera
                     continue
                 }
             }
-            guard !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
-                !repoURL.localizedCaseInsensitiveContains("apt.modmyi.com"),
-                !repoURL.localizedCaseInsensitiveContains("cydia.zodttd.com"),
+            guard !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"), //replaced by repo.chariz.com
+                !repoURL.localizedCaseInsensitiveContains("apt.modmyi.com"), //see: https://github.com/Sileo/Sileo/pull/26
+                !repoURL.localizedCaseInsensitiveContains("cydia.zodttd.com"), //see: https://github.com/Sileo/Sileo/pull/26
                 !hasRepo(with: URL(string: repoURL)!)
                 else { continue }
 

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -129,6 +129,8 @@ final class RepoManager {
         for url in urls {
             guard !hasRepo(with: url),
                 url.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
+                url.host?.localizedCaseInsensitiveContains("apt.modmyi.com") == false,
+                url.host?.localizedCaseInsensitiveContains("cydia.zodttd.com") == false,
                 url.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false else { continue }
 
             repoListLock.wait()
@@ -190,6 +192,8 @@ final class RepoManager {
                 }
             }
             guard !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
+                !repoURL.localizedCaseInsensitiveContains("apt.modmyi.com"),
+                !repoURL.localizedCaseInsensitiveContains("cydia.zodttd.com"),
                 !hasRepo(with: URL(string: repoURL)!)
                 else { continue }
 


### PR DESCRIPTION
Don't add modmyi or zodttd repos. These repos have almost 60K packages combined, out of which only about 400 work on iOS 11, with even less working on iOS 12 or 13. Furthermore, these repos do not have SHA256 hashes so Sileo can't even download from them directly.

Repoproxy indexes the 400 that work with SHA256 hashes, and since these repos are archived, they're never changing so repoproxy's index will always be up-to-date for these repos. 

Not adding these repos makes Sileo significantly faster due to having to index far less packages, considering these packages don't even work on the latest iOS versions. (And these repos don't work properly in Sileo anyways)