### PR TITLE
Don't subclass from NSObject where it's not needed. Fixes #5

### DIFF
--- a/Sileo/Backend/DPKG Wrapper/DpkgWrapper.swift
+++ b/Sileo/Backend/DPKG Wrapper/DpkgWrapper.swift
@@ -45,7 +45,7 @@ enum pkgpriority {
     unset
 }
 
-class DpkgWrapper: NSObject {
+class DpkgWrapper {
     private static let priorityinfos: [String: pkgpriority] = ["required": .required,
                                                                "important": .important,
                                                                "standard": .standard,

--- a/Sileo/Backend/Download Manager/DownloadManager.swift
+++ b/Sileo/Backend/Download Manager/DownloadManager.swift
@@ -73,7 +73,7 @@ class DownloadManager {
     
     var repoDownloadOverrideProviders: [String: Set<NSObject>] = [:]
     
-    var viewController = DownloadsTableViewController(nibName: "DownloadsTableViewController", bundle: nil)
+    let viewController = DownloadsTableViewController(nibName: "DownloadsTableViewController", bundle: nil)
     
     public func downloadingPackages() -> Int {
         var downloadsCount = 0

--- a/Sileo/Backend/Download Manager/DownloadManager.swift
+++ b/Sileo/Backend/Download Manager/DownloadManager.swift
@@ -17,7 +17,7 @@ public enum DownloadManagerQueue: Int {
     case none
 }
 
-class DownloadManager: NSObject {
+class DownloadManager {
     static let reloadNotification = Notification.Name("SileoDownloadManagerReloaded")
     static let lockStateChangeNotification = Notification.Name("SileoDownloadManagerLockStateChanged")
     
@@ -73,13 +73,7 @@ class DownloadManager: NSObject {
     
     var repoDownloadOverrideProviders: [String: Set<NSObject>] = [:]
     
-    var viewController: DownloadsTableViewController
-    
-    override init() {
-        viewController = DownloadsTableViewController(nibName: "DownloadsTableViewController", bundle: nil)
-        
-        super.init()
-    }
+    var viewController = DownloadsTableViewController(nibName: "DownloadsTableViewController", bundle: nil)
     
     public func downloadingPackages() -> Int {
         var downloadsCount = 0

--- a/Sileo/Backend/Package Manager/PackageListManager.swift
+++ b/Sileo/Backend/Package Manager/PackageListManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreSpotlight
 
-class PackageListManager: NSObject {
+class PackageListManager {
     static let reloadNotification = Notification.Name("SileoPackageCacheReloaded")
     static let didUpdateNotification = Notification.Name("SileoDatabaseDidUpdateNotification")
     

--- a/Sileo/UI/SettingsViewController/Base/SettingsHeaderViewDisplayable.swift
+++ b/Sileo/UI/SettingsViewController/Base/SettingsHeaderViewDisplayable.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol SettingsHeaderViewDisplayable: NSObject {
+protocol SettingsHeaderViewDisplayable {
     func headerHeight(forWidth: CGFloat) -> CGFloat
 }


### PR DESCRIPTION
Don't subclass from NSObject where we don't need to. This reduces overhead from invoking the Objective-C runtime