### PR TITLE
Support Elucubratus APT within Sileo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TARGET_CODESIGN = $(shell which ldid)
 ARCH            = arm64
 PLATFORM        = iphoneos
 DEB_ARCH        = iphoneos-arm
-DEB_DEPENDS     = firmware (>= 12.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.32-4), dpkg (>= 1.20.0), apt (>= 2.3.0)
+DEB_DEPENDS     = firmware (>= 12.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.31), dpkg (>= 1.19), apt (>= 1.8)
 PREFIX          =
 else ifeq ($(SILEO_PLATFORM),darwin-arm64)
 # These trues are temporary
@@ -53,7 +53,7 @@ export DISPLAY_NAME = "Sileo-Beta"
 SILEO_ID   = org.coolstar.sileobeta
 SILEO_NAME = Sileo (Beta Channel)
 SILEO_APP  = Sileo-Beta.app
-SILEO_VERSION = $$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $(SILEO_STAGE_DIR)/$(PREFIX)/Applications/$(SILEO_APP)/Info.plist)+$$(git show -s --format=%cd --date=short HEAD | sed s/-//g).$$(git show -s --format=%cd --date=unix HEAD | sed s/-//g).$$(git rev-parse --short=7 HEAD)
+SILEO_VERSION = $$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $(SILEO_STAGE_DIR)/$(PREFIX)/Applications/$(SILEO_APP)/Info.plist)-tale+$$(git show -s --format=%cd --date=short HEAD | sed s/-//g).$$(git show -s --format=%cd --date=unix HEAD | sed s/-//g).$$(git rev-parse --short=7 HEAD)
 else
 export PRODUCT_BUNDLE_IDENTIFIER = "org.coolstar.SileoStore"
 export DISPLAY_NAME = "Sileo"

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -74,7 +74,7 @@ final class RepoManager {
         Suites: iphoneos-arm64/\(cfMajorVersion)
         Components: main
         """
-        jailbreakRepo.entryFile = "/etc/apt/sources.list.d/procursus.sources"
+        jailbreakRepo.entryFile = "/etc/apt/sileo.list.d/procursus.sources"
         repoList.append(jailbreakRepo)
         repoListLock.signal()
         
@@ -91,13 +91,13 @@ final class RepoManager {
             Suites: stable
             Components: main
             """
-            bigBoss.entryFile = "/etc/apt/sources.list.d/sileo.sources"
+            bigBoss.entryFile = "/etc/apt/sileo.list.d/sileo.sources"
             repoList.append(bigBoss)
             
             writeListToFile()
         }
         #else
-        let directory = URL(fileURLWithPath: "/etc/apt/sources.list.d")
+        let directory = URL(fileURLWithPath: "/etc/apt/sileo.list.d")
         for item in directory.implicitContents {
             if item.pathExtension == "list" {
                 parseListFile(at: item)
@@ -119,7 +119,6 @@ final class RepoManager {
             }
             
             guard !hasRepo(with: normalizedURL),
-                  normalizedURL.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
                   normalizedURL.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false
             else {
                 continue
@@ -135,7 +134,7 @@ final class RepoManager {
             Suites: ./
             Components:
             """
-            repo.entryFile = "/etc/apt/sources.list.d/sileo.sources"
+            repo.entryFile = "/etc/apt/sileo.list.d/sileo.sources"
             
             repoList.append(repo)
             repoListLock.signal()
@@ -187,8 +186,7 @@ final class RepoManager {
         }
         
         for repoURL in uris {
-            guard !repoURL.localizedCaseInsensitiveContains("apt.bingner.com"),
-                  !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
+            guard !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
                   !hasRepo(with: URL(string: repoURL)!)
             else {
                 continue
@@ -903,10 +901,10 @@ final class RepoManager {
         #else
         
         var sileoList = ""
-        if FileManager.default.fileExists(atPath: "/etc/apt/sources.list.d/procursus.sources") ||
-           FileManager.default.fileExists(atPath: "/etc/apt/sources.list.d/chimera.sources") ||
-           FileManager.default.fileExists(atPath: "/etc/apt/sources.list.d/electra.list") {
-            sileoList = "/etc/apt/sources.list.d/sileo.sources"
+        if FileManager.default.fileExists(atPath: "/etc/apt/sileo.list.d/procursus.sources") ||
+           FileManager.default.fileExists(atPath: "/etc/apt/sileo.list.d/chimera.sources") ||
+           FileManager.default.fileExists(atPath: "/etc/apt/sileo.list.d/electra.list") {
+            sileoList = "/etc/apt/sileo.list.d/sileo.sources"
         } else {
             sileoList = "/etc/apt/sileo.list.d/sileo.sources"
         }

--- a/layout/DEBIAN/control.in
+++ b/layout/DEBIAN/control.in
@@ -2,7 +2,7 @@ Package: @@PACKAGE_ID@@
 Name: @@PACKAGE_NAME@@
 Version: @@MARKETING_VERSION@@
 Author: Sileo Team <getsileoapp@gmail.com>
-Maintainer: CoolStar <coolstarorganization@gmail.com>
+Maintainer: Aarnav Tale <support@renai.me>
 Description: A modern APT package manager frontend
 Architecture: @@DEB_ARCH@@
 Depends: @@DEB_DEPENDS@@

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -7,36 +7,36 @@ cr="\n"
 # Elucubratus Patches Begin
 if [ -s $sourcesDir/cydia.list ] && grep -Fxq "deb https://apt.bingner.com/ ./" $sourcesDir/cydia.list;
 then
-        sourcesDir="/etc/apt/sileo.list.d"
-        if ! [ -s $sourcesDir ];
-        then
-                mkdir -p $sourcesDir
-        fi
+		sourcesDir="/etc/apt/sileo.list.d"
+		if ! [ -s $sourcesDir ];
+		then
+				mkdir -p $sourcesDir
+		fi
 
-        if ! [ -s $sourcesDir/elucubratus.sources ];
-        then
-                echo "Installed Bingner/Elucubratus Repo"
-                echo -e "" > $sourcesDir/elucubratus.sources
-                sed -i.bak '1s;^;Types: deb\
+		if ! [ -s $sourcesDir/elucubratus.sources ];
+		then
+				echo "Installed Bingner/Elucubratus Repo"
+				echo -e "" > $sourcesDir/elucubratus.sources
+				sed -i.bak '1s;^;Types: deb\
 URIs: https://apt.bingner.com/\
 Suites: ./\
 Components:\
 \
 ;' $sourcesDir/elucubratus.sources
-        fi
+		fi
 fi
 
 touch $sourcesDir/sileo.sources
 # Elucubratus Patches End
 
 if ! [ -s $sourcesDir/sileo.sources ]; then
-        echo -e "" > $sourcesDir/sileo.sources
+		echo -e "" > $sourcesDir/sileo.sources
 fi
 
 if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;
 then
-        echo "Installed Chariz Repo"
-        sed -i.bak '1s;^;Types: deb\
+		echo "Installed Chariz Repo"
+		sed -i.bak '1s;^;Types: deb\
 URIs: https://repo.chariz.com/\
 Suites: ./\
 Components:\
@@ -46,8 +46,8 @@ fi
 
 if ! grep -Fxq "URIs: https://repo.dynastic.co/" $sourcesDir/sileo.sources ;
 then
-        echo "Installed Dynastic Repo"
-        sed -i.bak '1s;^;Types: deb\
+		echo "Installed Dynastic Repo"
+		sed -i.bak '1s;^;Types: deb\
 URIs: https://repo.dynastic.co/\
 Suites: ./\
 Components:\
@@ -57,8 +57,8 @@ fi
 
 if ! grep -Fxq "URIs: https://repo.packix.com/" $sourcesDir/sileo.sources ;
 then
-        echo "Installed Packix Repo"
-        sed -i.bak '1s;^;Types: deb\
+		echo "Installed Packix Repo"
+		sed -i.bak '1s;^;Types: deb\
 URIs: https://repo.packix.com/\
 Suites: ./\
 Components:\
@@ -68,8 +68,8 @@ fi
 
 if ! grep -Fxq "URIs: http://apt.thebigboss.org/repofiles/cydia/" $sourcesDir/sileo.sources ;
 then
-        echo "Installed BigBoss Repo"
-        sed -i.bak '1s;^;Types: deb\
+		echo "Installed BigBoss Repo"
+		sed -i.bak '1s;^;Types: deb\
 URIs: http://apt.thebigboss.org/repofiles/cydia/\
 Suites: stable\
 Components: main\
@@ -92,21 +92,34 @@ rm -f $sourcesDir/sileo.sources.bak 2> /dev/null || true
 rm -f $sourcesDir/sileo-base.sources.bak 2> /dev/null || true
 
 function finish() {
-        f="${1}"
+		f="${1}"
 
-        # No control fd: bail out
-        [[ -z "${f}" || -z "${SILEO}" ]] && return
-        sileo=(${SILEO})
+		# No control fd: bail out
+		[[ -z "${f}" || -z "${SILEO}" ]] && return
+		sileo=(${SILEO})
 
-        # Sileo control fd version < 1: bail out
-        [[ ${sileo[1]} -ge 1 ]] || return
+		# Sileo control fd version < 1: bail out
+		[[ ${sileo[1]} -ge 1 ]] || return
 
-        echo "finish:${f}" >&${sileo[0]}
+		echo "finish:${f}" >&${sileo[0]}
 }
 
-finish uicache
+if [[ "$1" == triggered ]];
+then
+	if [[ -z "${SILEO}" ]];
+	then
+		echo "Not running in Sileo. Trigger UICache"
+		uicache -p /Applications/@@SILEO_APP@@
+		exit 0
+	fi
 
-if [[ -z ${SILEO} ]]; then echo "Not running in Sileo. Trigger UICache"; fi
-if [[ -z ${SILEO} ]]; then uicache -p /Applications/@@SILEO_APP@@; fi
-
-exit 0
+	if [[ "$2" == "/Applications" ]];
+	then
+		finish uicache
+	elif [[ "$2" == "/Library/MobileSubstrate/DynamicLibraries" && -n "${SILEO}" ]];
+	then
+		finish restart
+	fi
+	
+	exit 0
+fi

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -2,9 +2,32 @@
 sourcesDir="/etc/apt/sources.list.d"
 
 rm /etc/apt/sources.list.d/sileo.list 2> /dev/null || true
-touch $sourcesDir/sileo.sources
-
 cr="\n"
+
+# Elucubratus Patches Begin
+if [ -s $sourcesDir/cydia.list ] && grep -Fxq "deb https://apt.bingner.com/ ./" $sourcesDir/cydia.list;
+then
+        sourcesDir="/etc/apt/sileo.list.d"
+        if ! [ -s $sourcesDir ];
+        then
+                mkdir -p $sourcesDir
+        fi
+
+        if ! [ -s $sourcesDir/elucubratus.sources ];
+        then
+                echo "Installed Bingner/Elucubratus Repo"
+                echo -e "" > $sourcesDir/elucubratus.sources
+                sed -i.bak '1s;^;Types: deb\
+URIs: https://apt.bingner.com/\
+Suites: ./\
+Components:\
+\
+;' $sourcesDir/elucubratus.sources
+        fi
+fi
+
+touch $sourcesDir/sileo.sources
+# Elucubratus Patches End
 
 if ! [ -s $sourcesDir/sileo.sources ]; then
         echo -e "" > $sourcesDir/sileo.sources

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -33,6 +33,17 @@ if ! [ -s $sourcesDir/sileo.sources ]; then
 		echo -e "" > $sourcesDir/sileo.sources
 fi
 
+if ! grep -Fxq "URIs: https://repo.getsileo.app/" $sourcesDir/sileo.sources ;
+then
+		echo "Installed Sileo Repo"
+		sed -i.bak '1s;^;Types: deb\
+URIs: https://repo.getsileo.app/\
+Suites: ./\
+Components:\
+\
+;' $sourcesDir/sileo.sources
+fi
+
 if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;
 then
 		echo "Installed Chariz Repo"

--- a/layout/DEBIAN/triggers
+++ b/layout/DEBIAN/triggers
@@ -1,2 +1,2 @@
 interest /Applications
-
+interest /Library/MobileSubstrate/DynamicLibraries


### PR DESCRIPTION
Add support for Elucubratus based jailbreaks.
The APT JSON output provided by Elucubratus differs slightly from the one provided by Procursus.
As such, efforts had to be made to support parsing both of these outputs and getting the same results.

This PR also includes other support commits I keep so that we can maintain the fork properly:
- sileo.list.d is used over sources.list.d, to avoid the locale warnings that's pending a patch on Cydia.
- A patch to support the Elucubratus base binaries and paths rather than hardcoded Procursus paths. Perhaps @Diatrus and I can come up with a more elegant solution for this?
- The postinst change is something I'm really unsure about because without it I can't trigger a respring properly
- The remaining control and default sources changes will be removed when this pull request is ready (when 2.1 is ready)

I also realize the formatting may be off because these patches aren't as up to date as I would like them to be.