### PR TITLE
Fix spurious `-e`s in sileo.sources

### DIFF
--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -24,7 +24,7 @@ case "$1" in
 		cr="\n"
 
 		if ! [ -s "$sourcesDir/sileo.sources" ]; then
-			echo -e "" > $sourcesDir/sileo.sources
+			echo "" > $sourcesDir/sileo.sources
 		fi
 
 		if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;


### PR DESCRIPTION
The `-e` and `-n` arguments to `echo` are nonstandard, they will not work in dash. It's not needed anyway, because there are no escape sequences being used here.