### PR TITLE
Implement a better parser for APT Json output

### DIFF
--- a/Deps/liblzma/liblzma.5-mac.tbd
+++ b/Deps/liblzma/liblzma.5-mac.tbd
@@ -7,6 +7,7 @@ current-version: 8.5
 compatibility-version: 8
 exports:
   - targets:         [ x86_64, x86_64-maccatalyst ]
+    symbols:         [ _lzma_alone_decoder, _lzma_alone_encoder, _lzma_auto_decoder, 
                        _lzma_block_buffer_bound, _lzma_block_buffer_decode, _lzma_block_buffer_encode, 
                        _lzma_block_compressed_size, _lzma_block_decoder, _lzma_block_encoder, 
                        _lzma_block_header_decode, _lzma_block_header_encode, _lzma_block_header_size, 

--- a/Deps/liblzma/liblzma.5-mac.tbd
+++ b/Deps/liblzma/liblzma.5-mac.tbd
@@ -1,0 +1,42 @@
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64, x86_64-maccatalyst ]
+flags:           [ not_app_extension_safe ]
+install-name:    '/opt/procursus/lib/liblzma.5.dylib'
+current-version: 8.5
+compatibility-version: 8
+exports:
+  - targets:         [ x86_64, x86_64-maccatalyst ]
+                       _lzma_block_buffer_bound, _lzma_block_buffer_decode, _lzma_block_buffer_encode, 
+                       _lzma_block_compressed_size, _lzma_block_decoder, _lzma_block_encoder, 
+                       _lzma_block_header_decode, _lzma_block_header_encode, _lzma_block_header_size, 
+                       _lzma_block_total_size, _lzma_block_uncomp_encode, _lzma_block_unpadded_size, 
+                       _lzma_check_is_supported, _lzma_check_size, _lzma_code, _lzma_cputhreads, 
+                       _lzma_crc32, _lzma_crc64, _lzma_easy_buffer_encode, _lzma_easy_decoder_memusage, 
+                       _lzma_easy_encoder, _lzma_easy_encoder_memusage, _lzma_end, 
+                       _lzma_filter_decoder_is_supported, _lzma_filter_encoder_is_supported, 
+                       _lzma_filter_flags_decode, _lzma_filter_flags_encode, _lzma_filter_flags_size, 
+                       _lzma_filters_copy, _lzma_filters_update, _lzma_get_check, 
+                       _lzma_get_progress, _lzma_index_append, _lzma_index_block_count, 
+                       _lzma_index_buffer_decode, _lzma_index_buffer_encode, _lzma_index_cat, 
+                       _lzma_index_checks, _lzma_index_decoder, _lzma_index_dup, 
+                       _lzma_index_encoder, _lzma_index_end, _lzma_index_file_size, 
+                       _lzma_index_hash_append, _lzma_index_hash_decode, _lzma_index_hash_end, 
+                       _lzma_index_hash_init, _lzma_index_hash_size, _lzma_index_init, 
+                       _lzma_index_iter_init, _lzma_index_iter_locate, _lzma_index_iter_next, 
+                       _lzma_index_iter_rewind, _lzma_index_memusage, _lzma_index_memused, 
+                       _lzma_index_size, _lzma_index_stream_count, _lzma_index_stream_flags, 
+                       _lzma_index_stream_padding, _lzma_index_stream_size, _lzma_index_total_size, 
+                       _lzma_index_uncompressed_size, _lzma_lzma_preset, _lzma_memlimit_get, 
+                       _lzma_memlimit_set, _lzma_memusage, _lzma_mf_is_supported, 
+                       _lzma_mode_is_supported, _lzma_physmem, _lzma_properties_decode, 
+                       _lzma_properties_encode, _lzma_properties_size, _lzma_raw_buffer_decode, 
+                       _lzma_raw_buffer_encode, _lzma_raw_decoder, _lzma_raw_decoder_memusage, 
+                       _lzma_raw_encoder, _lzma_raw_encoder_memusage, _lzma_stream_buffer_bound, 
+                       _lzma_stream_buffer_decode, _lzma_stream_buffer_encode, _lzma_stream_decoder, 
+                       _lzma_stream_encoder, _lzma_stream_encoder_mt, _lzma_stream_encoder_mt_memusage, 
+                       _lzma_stream_flags_compare, _lzma_stream_footer_decode, _lzma_stream_footer_encode, 
+                       _lzma_stream_header_decode, _lzma_stream_header_encode, _lzma_version_number, 
+                       _lzma_version_string, _lzma_vli_decode, _lzma_vli_encode, 
+                       _lzma_vli_size ]
+...

--- a/Sileo.xcodeproj/project.pbxproj
+++ b/Sileo.xcodeproj/project.pbxproj
@@ -127,8 +127,6 @@
 		E14C5ED226680E090080BFCE /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E14C5ED026680E030080BFCE /* libz.tbd */; };
 		E14C5EE9266810A30080BFCE /* GZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14C5EE8266810A30080BFCE /* GZIP.swift */; };
 		E14C5EEA266810A30080BFCE /* GZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14C5EE8266810A30080BFCE /* GZIP.swift */; };
-		E14C5EEF2668223D0080BFCE /* liblzma.5.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E14C5EEB266822120080BFCE /* liblzma.5.tbd */; platformFilter = ios; settings = {ATTRIBUTES = (Weak, ); }; };
-		E14C5EF02668227C0080BFCE /* liblzma.5.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E14C5ED326680E9B0080BFCE /* liblzma.5.tbd */; };
 		E166F6F9260A6FFF00663FA1 /* CanisterResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E166F6F8260A6FFF00663FA1 /* CanisterResolver.swift */; };
 		E166F6FA260A6FFF00663FA1 /* CanisterResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E166F6F8260A6FFF00663FA1 /* CanisterResolver.swift */; };
 		E18CD2D1262C8E7500FF499C /* NewsResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18CD2D0262C8E7500FF499C /* NewsResolver.swift */; };
@@ -163,6 +161,8 @@
 		E1C90271263D847D00569D1E /* AmyDownloadParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9026F263D847D00569D1E /* AmyDownloadParser.swift */; };
 		E1D44BB82665093A00A12A77 /* SileoTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D44BB72665093A00A12A77 /* SileoTableView.swift */; };
 		E1D44BB92665093A00A12A77 /* SileoTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D44BB72665093A00A12A77 /* SileoTableView.swift */; };
+		E1D6DFB7268BA730005BF9EA /* APTJsonParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D6DFB6268BA72F005BF9EA /* APTJsonParser.swift */; };
+		E1D6DFB8268BA730005BF9EA /* APTJsonParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D6DFB6268BA72F005BF9EA /* APTJsonParser.swift */; };
 		E1DC86062669673600B3DC42 /* AmyLogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DC86052669673600B3DC42 /* AmyLogManager.swift */; };
 		E1DC86072669673600B3DC42 /* AmyLogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DC86052669673600B3DC42 /* AmyLogManager.swift */; };
 		E1DC860D26697CD600B3DC42 /* Pride@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E1DC860926697CD600B3DC42 /* Pride@2x.png */; };
@@ -178,6 +178,16 @@
 		E1DDA6372630830300E889A5 /* AmyNetworkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DDA6362630830300E889A5 /* AmyNetworkResolver.swift */; };
 		E1DDA6382630830300E889A5 /* AmyNetworkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DDA6362630830300E889A5 /* AmyNetworkResolver.swift */; };
 		E1EA1CFF2615008100E56882 /* LNZTreeView in Frameworks */ = {isa = PBXBuildFile; productRef = E1EA1CFE2615008100E56882 /* LNZTreeView */; };
+		E1EB035F268BA3D40097CEE1 /* liblzma.5-mac.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E1EB035D268BA3C30097CEE1 /* liblzma.5-mac.tbd */; platformFilter = maccatalyst; };
+		E1EB0360268BA3D70097CEE1 /* liblzma.5.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E1EB035E268BA3C30097CEE1 /* liblzma.5.tbd */; platformFilter = ios; };
+		E1EB0362268BA45C0097CEE1 /* DownloadsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0361268BA45C0097CEE1 /* DownloadsTableViewCell.swift */; };
+		E1EB0363268BA45C0097CEE1 /* DownloadsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0361268BA45C0097CEE1 /* DownloadsTableViewCell.swift */; };
+		E1EB0365268BA4690097CEE1 /* DownloadsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0364268BA4690097CEE1 /* DownloadsTableViewController.swift */; };
+		E1EB0366268BA4690097CEE1 /* DownloadsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0364268BA4690097CEE1 /* DownloadsTableViewController.swift */; };
+		E1EB0368268BA4B00097CEE1 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0367268BA4B00097CEE1 /* DownloadManager.swift */; };
+		E1EB0369268BA4B00097CEE1 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB0367268BA4B00097CEE1 /* DownloadManager.swift */; };
+		E1EB036B268BA4C30097CEE1 /* DependencyResolverAccelerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB036A268BA4C30097CEE1 /* DependencyResolverAccelerator.swift */; };
+		E1EB036C268BA4C30097CEE1 /* DependencyResolverAccelerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EB036A268BA4C30097CEE1 /* DependencyResolverAccelerator.swift */; };
 		E1F10B1E2663A60100DA726E /* SourcesTableViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F10B1D2663A60100DA726E /* SourcesTableViewFooter.swift */; };
 		E1F10B1F2663A60100DA726E /* SourcesTableViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F10B1D2663A60100DA726E /* SourcesTableViewFooter.swift */; };
 		F102D1E322CD514C00A4C9BA /* WishListManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F102D1E222CD514C00A4C9BA /* WishListManager.swift */; };
@@ -284,12 +294,8 @@
 		F139D14622EA9209007F5C0D /* NewsArticlesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CFE8CB152274589F0066D501 /* NewsArticlesViewController.xib */; };
 		F13AD30F23F9306F0035986E /* sileo-apt.conf in Resources */ = {isa = PBXBuildFile; fileRef = F13AD30E23F9306F0035986E /* sileo-apt.conf */; };
 		F13AEE5322F52F98004BAA05 /* DownloadPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5222F52F98004BAA05 /* DownloadPackage.swift */; };
-		F13AEE5622F5613C004BAA05 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5522F5613C004BAA05 /* DownloadManager.swift */; };
-		F13AEE5722F5613C004BAA05 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5522F5613C004BAA05 /* DownloadManager.swift */; };
 		F13AEE5B22F62B9D004BAA05 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5A22F62B9D004BAA05 /* Download.swift */; };
 		F13AEE5C22F62B9D004BAA05 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5A22F62B9D004BAA05 /* Download.swift */; };
-		F13AEE5E22F63122004BAA05 /* DownloadsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5D22F63122004BAA05 /* DownloadsTableViewController.swift */; };
-		F13AEE5F22F63122004BAA05 /* DownloadsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5D22F63122004BAA05 /* DownloadsTableViewController.swift */; };
 		F13AEE6022F64A86004BAA05 /* DownloadPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE5222F52F98004BAA05 /* DownloadPackage.swift */; };
 		F13AEE6322F69C47004BAA05 /* EditableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE6222F69C47004BAA05 /* EditableTableView.swift */; };
 		F13AEE6422F69C47004BAA05 /* EditableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13AEE6222F69C47004BAA05 /* EditableTableView.swift */; };
@@ -391,8 +397,6 @@
 		F1AB912E22ED0D220054341B /* BaseSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AB912C22ED0D220054341B /* BaseSubtitleTableViewCell.swift */; };
 		F1AB913022ED12070054341B /* SourcesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AB912F22ED12070054341B /* SourcesTableViewCell.swift */; };
 		F1AB913122ED12070054341B /* SourcesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AB912F22ED12070054341B /* SourcesTableViewCell.swift */; };
-		F1AB913322ED133D0054341B /* DownloadsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AB913222ED133D0054341B /* DownloadsTableViewCell.swift */; };
-		F1AB913422ED133D0054341B /* DownloadsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AB913222ED133D0054341B /* DownloadsTableViewCell.swift */; };
 		F1B4B57D216197DD004F160E /* SourcesErrorsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F1B4B57B216197DD004F160E /* SourcesErrorsViewController.xib */; };
 		F1B99F0720DBE64700374C27 /* PackageListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F1B99F0520DBE64700374C27 /* PackageListViewController.xib */; };
 		F1C5D98622D123FA0021BD89 /* DepictionBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C5D98522D123FA0021BD89 /* DepictionBaseView.swift */; };
@@ -465,8 +469,6 @@
 		F1FF7A6424FAEE5E0088F88B /* DepictionLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7A6224FAEE5E0088F88B /* DepictionLayerView.swift */; };
 		F1FF7A6724FAF0310088F88B /* FeaturedLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7A6624FAF0310088F88B /* FeaturedLayerView.swift */; };
 		F1FF7A6824FAF0310088F88B /* FeaturedLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7A6624FAF0310088F88B /* FeaturedLayerView.swift */; };
-		F1FFE5DA23D5145300916364 /* DependencyResolverAccelerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FFE5D923D5145300916364 /* DependencyResolverAccelerator.swift */; };
-		F1FFE5DB23D5145300916364 /* DependencyResolverAccelerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FFE5D923D5145300916364 /* DependencyResolverAccelerator.swift */; };
 		FB208DC324D709B7000297FB /* SileoTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB208DC224D709B7000297FB /* SileoTheme.swift */; };
 		FB208DC524D70A91000297FB /* SileoThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB208DC424D70A91000297FB /* SileoThemeManager.swift */; };
 		FB208DC624D70D5B000297FB /* SileoThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB208DC424D70A91000297FB /* SileoThemeManager.swift */; };
@@ -801,7 +803,6 @@
 		E14C5EC9266804120080BFCE /* BZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BZIP.swift; sourceTree = "<group>"; };
 		E14C5ECE26680DF40080BFCE /* libz.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.1.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/lib/libz.1.tbd; sourceTree = DEVELOPER_DIR; };
 		E14C5ED026680E030080BFCE /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
-		E14C5ED326680E9B0080BFCE /* liblzma.5.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = liblzma.5.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/lib/liblzma.5.tbd; sourceTree = DEVELOPER_DIR; };
 		E14C5ED726680F340080BFCE /* lzma.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lzma.h; sourceTree = "<group>"; };
 		E14C5EDA26680F340080BFCE /* index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = index.h; sourceTree = "<group>"; };
 		E14C5EDB26680F340080BFCE /* version.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
@@ -818,7 +819,6 @@
 		E14C5EE626680F350080BFCE /* filter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filter.h; sourceTree = "<group>"; };
 		E14C5EE726680F350080BFCE /* base.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
 		E14C5EE8266810A30080BFCE /* GZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GZIP.swift; sourceTree = "<group>"; };
-		E14C5EEB266822120080BFCE /* liblzma.5.tbd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.text-based-dylib-definition"; path = liblzma.5.tbd; sourceTree = "<group>"; };
 		E166F6F8260A6FFF00663FA1 /* CanisterResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanisterResolver.swift; sourceTree = "<group>"; };
 		E1777824266006290091AFAB /* LaunchAsRoot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LaunchAsRoot.h; sourceTree = "<group>"; };
 		E18CD2D0262C8E7500FF499C /* NewsResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsResolver.swift; sourceTree = "<group>"; };
@@ -840,12 +840,19 @@
 		E1C9026F263D847D00569D1E /* AmyDownloadParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmyDownloadParser.swift; sourceTree = "<group>"; };
 		E1D28C762660018100DACF31 /* Sileo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sileo.entitlements; sourceTree = "<group>"; };
 		E1D44BB72665093A00A12A77 /* SileoTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SileoTableView.swift; sourceTree = "<group>"; };
+		E1D6DFB6268BA72F005BF9EA /* APTJsonParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APTJsonParser.swift; sourceTree = "<group>"; };
 		E1DC86052669673600B3DC42 /* AmyLogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmyLogManager.swift; sourceTree = "<group>"; };
 		E1DC860926697CD600B3DC42 /* Pride@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Pride@2x.png"; sourceTree = "<group>"; };
 		E1DC860A26697CD600B3DC42 /* Pride~ipad@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Pride~ipad@2x.png"; sourceTree = "<group>"; };
 		E1DC860B26697CD600B3DC42 /* Pride~ipad@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Pride~ipad@3x.png"; sourceTree = "<group>"; };
 		E1DC860C26697CD600B3DC42 /* Pride@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Pride@3x.png"; sourceTree = "<group>"; };
 		E1DDA6362630830300E889A5 /* AmyNetworkResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmyNetworkResolver.swift; sourceTree = "<group>"; };
+		E1EB035D268BA3C30097CEE1 /* liblzma.5-mac.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; path = "liblzma.5-mac.tbd"; sourceTree = "<group>"; };
+		E1EB035E268BA3C30097CEE1 /* liblzma.5.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; path = liblzma.5.tbd; sourceTree = "<group>"; };
+		E1EB0361268BA45C0097CEE1 /* DownloadsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadsTableViewCell.swift; sourceTree = "<group>"; };
+		E1EB0364268BA4690097CEE1 /* DownloadsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadsTableViewController.swift; sourceTree = "<group>"; };
+		E1EB0367268BA4B00097CEE1 /* DownloadManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
+		E1EB036A268BA4C30097CEE1 /* DependencyResolverAccelerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyResolverAccelerator.swift; sourceTree = "<group>"; };
 		E1F10B062662E25800DA726E /* status */ = {isa = PBXFileReference; lastKnownFileType = text; path = status; sourceTree = "<group>"; };
 		E1F10B1D2663A60100DA726E /* SourcesTableViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcesTableViewFooter.swift; sourceTree = "<group>"; };
 		F102D1E222CD514C00A4C9BA /* WishListManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListManager.swift; sourceTree = "<group>"; };
@@ -868,9 +875,7 @@
 		F139D14C22EA9209007F5C0D /* Sileo Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sileo Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F13AD30E23F9306F0035986E /* sileo-apt.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sileo-apt.conf"; sourceTree = "<group>"; };
 		F13AEE5222F52F98004BAA05 /* DownloadPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadPackage.swift; sourceTree = "<group>"; };
-		F13AEE5522F5613C004BAA05 /* DownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
 		F13AEE5A22F62B9D004BAA05 /* Download.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Download.swift; sourceTree = "<group>"; };
-		F13AEE5D22F63122004BAA05 /* DownloadsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsTableViewController.swift; sourceTree = "<group>"; };
 		F13AEE6222F69C47004BAA05 /* EditableTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTableView.swift; sourceTree = "<group>"; };
 		F13AEE6B22F75913004BAA05 /* UIPasteboard+Sources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Sources.swift"; sourceTree = "<group>"; };
 		F13AEE7222F76B63004BAA05 /* InstalledContentsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledContentsViewController.swift; sourceTree = "<group>"; };
@@ -962,7 +967,6 @@
 		F1AB912922ED09AE0054341B /* SourceProgressIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceProgressIndicatorView.swift; sourceTree = "<group>"; };
 		F1AB912C22ED0D220054341B /* BaseSubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		F1AB912F22ED12070054341B /* SourcesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourcesTableViewCell.swift; sourceTree = "<group>"; };
-		F1AB913222ED133D0054341B /* DownloadsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsTableViewCell.swift; sourceTree = "<group>"; };
 		F1B4B57B216197DD004F160E /* SourcesErrorsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SourcesErrorsViewController.xib; sourceTree = "<group>"; };
 		F1B99F0520DBE64700374C27 /* PackageListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PackageListViewController.xib; sourceTree = "<group>"; };
 		F1C5D98522D123FA0021BD89 /* DepictionBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepictionBaseView.swift; sourceTree = "<group>"; };
@@ -1028,7 +1032,6 @@
 		F1FCE029213A0BE400D4697A /* InstalledContentsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InstalledContentsViewController.xib; sourceTree = "<group>"; };
 		F1FF7A6224FAEE5E0088F88B /* DepictionLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepictionLayerView.swift; sourceTree = "<group>"; };
 		F1FF7A6624FAF0310088F88B /* FeaturedLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedLayerView.swift; sourceTree = "<group>"; };
-		F1FFE5D923D5145300916364 /* DependencyResolverAccelerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyResolverAccelerator.swift; sourceTree = "<group>"; };
 		FB208DC224D709B7000297FB /* SileoTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SileoTheme.swift; sourceTree = "<group>"; };
 		FB208DC424D70A91000297FB /* SileoThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SileoThemeManager.swift; sourceTree = "<group>"; };
 		FB40261F23DE2B9C002D97FE /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
@@ -1067,7 +1070,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E14C5EF02668227C0080BFCE /* liblzma.5.tbd in Frameworks */,
 				E14C5ED226680E090080BFCE /* libz.tbd in Frameworks */,
 				E14C5EC8266803F30080BFCE /* libbz2.tbd in Frameworks */,
 				E19A5354261743BA00BB8A69 /* SQLite in Frameworks */,
@@ -1087,8 +1089,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1EB0360268BA3D70097CEE1 /* liblzma.5.tbd in Frameworks */,
+				E1EB035F268BA3D40097CEE1 /* liblzma.5-mac.tbd in Frameworks */,
 				E14C5ED126680E030080BFCE /* libz.tbd in Frameworks */,
-				E14C5EEF2668223D0080BFCE /* liblzma.5.tbd in Frameworks */,
 				E14C5EC7266803EA0080BFCE /* libbz2.tbd in Frameworks */,
 				E13638F22614F6C000698D55 /* SQLite in Frameworks */,
 				49E9BB132663392C0090475B /* LNPopupController.framework in Frameworks */,
@@ -1145,7 +1148,6 @@
 		33F3CD3020E059ED00B3A1D2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E14C5ED326680E9B0080BFCE /* liblzma.5.tbd */,
 				E14C5ED026680E030080BFCE /* libz.tbd */,
 				E14C5ECE26680DF40080BFCE /* libz.1.tbd */,
 				E14C5EC5266803DA0080BFCE /* libbz2.1.0.5.tbd */,
@@ -1541,7 +1543,8 @@
 		E14C5ED626680F340080BFCE /* liblzma */ = {
 			isa = PBXGroup;
 			children = (
-				E14C5EEB266822120080BFCE /* liblzma.5.tbd */,
+				E1EB035D268BA3C30097CEE1 /* liblzma.5-mac.tbd */,
+				E1EB035E268BA3C30097CEE1 /* liblzma.5.tbd */,
 				E14C5ED726680F340080BFCE /* lzma.h */,
 				E14C5ED926680F340080BFCE /* lzma */,
 			);
@@ -1961,7 +1964,7 @@
 		F162CCB120E82E1100226F10 /* Download Manager */ = {
 			isa = PBXGroup;
 			children = (
-				F13AEE5522F5613C004BAA05 /* DownloadManager.swift */,
+				E1EB0367268BA4B00097CEE1 /* DownloadManager.swift */,
 				F1705FED24CA15A2001596A0 /* DownloadOverrideProviding.swift */,
 			);
 			path = "Download Manager";
@@ -2077,7 +2080,7 @@
 		F19265CB2106B40300B31E13 /* DownloadCell */ = {
 			isa = PBXGroup;
 			children = (
-				F1AB913222ED133D0054341B /* DownloadsTableViewCell.swift */,
+				E1EB0361268BA45C0097CEE1 /* DownloadsTableViewCell.swift */,
 			);
 			path = DownloadCell;
 			sourceTree = "<group>";
@@ -2281,6 +2284,7 @@
 			isa = PBXGroup;
 			children = (
 				F1DD3CCC231118A500D86A52 /* APTWrapper.swift */,
+				E1D6DFB6268BA72F005BF9EA /* APTJsonParser.swift */,
 			);
 			path = "APT Wrapper";
 			sourceTree = "<group>";
@@ -2290,7 +2294,7 @@
 			children = (
 				F19265CB2106B40300B31E13 /* DownloadCell */,
 				F197493421368D8E0065E630 /* DownloadConfirmButton */,
-				F13AEE5D22F63122004BAA05 /* DownloadsTableViewController.swift */,
+				E1EB0364268BA4690097CEE1 /* DownloadsTableViewController.swift */,
 				F178CD8821323E3800F927FA /* DownloadsTableViewController.xib */,
 			);
 			path = DownloadsViewController;
@@ -2463,7 +2467,7 @@
 		F1FFE5D823D5142F00916364 /* Dependency Resolver */ = {
 			isa = PBXGroup;
 			children = (
-				F1FFE5D923D5145300916364 /* DependencyResolverAccelerator.swift */,
+				E1EB036A268BA4C30097CEE1 /* DependencyResolverAccelerator.swift */,
 			);
 			path = "Dependency Resolver";
 			sourceTree = "<group>";
@@ -2997,6 +3001,7 @@
 				F139D0B122EA9209007F5C0D /* DepictionScreenshotsView.swift in Sources */,
 				F139D0E122EA9209007F5C0D /* DepictionScreenshotsViewController.swift in Sources */,
 				FBBD003F240C31B4008E11B2 /* NewsGradientBackgroundView.swift in Sources */,
+				E1EB036C268BA4C30097CEE1 /* DependencyResolverAccelerator.swift in Sources */,
 				FB40262723DE5547002D97FE /* SettingsViewController.swift in Sources */,
 				F139D0F922EA9209007F5C0D /* DepictionSeparatorView.swift in Sources */,
 				F170606324CF54E0001596A0 /* SileoTableViewController.swift in Sources */,
@@ -3012,6 +3017,7 @@
 				F147E68722F2354B0048F868 /* DepictionSubpageViewController.swift in Sources */,
 				F139D0B522EA9209007F5C0D /* DepictionTabControl.swift in Sources */,
 				F139D0E722EA9209007F5C0D /* DepictionTabView.swift in Sources */,
+				E1EB0369268BA4B00097CEE1 /* DownloadManager.swift in Sources */,
 				F139D0C922EA9209007F5C0D /* DepictionTableButtonView.swift in Sources */,
 				F139D0B422EA9209007F5C0D /* DepictionTableTextView.swift in Sources */,
 				F170600224CCC7E6001596A0 /* PackageQueueButton.swift in Sources */,
@@ -3020,14 +3026,11 @@
 				F13AEE5C22F62B9D004BAA05 /* Download.swift in Sources */,
 				F14F7D5D240A7E7800062310 /* CSTextView.swift in Sources */,
 				F1AB912522ED05B90054341B /* DownloadConfirmButton.swift in Sources */,
-				F13AEE5722F5613C004BAA05 /* DownloadManager.swift in Sources */,
 				E1DC86072669673600B3DC42 /* AmyLogManager.swift in Sources */,
 				F1330EB22325644700971073 /* SileoContentView.swift in Sources */,
 				F13AEE6022F64A86004BAA05 /* DownloadPackage.swift in Sources */,
-				F1AB913422ED133D0054341B /* DownloadsTableViewCell.swift in Sources */,
 				E1C6C0D92677BFDE006228E0 /* KeychainManager.swift in Sources */,
 				F16115D2244D87CD003BF1E6 /* FeaturedButton.swift in Sources */,
-				F13AEE5F22F63122004BAA05 /* DownloadsTableViewController.swift in Sources */,
 				E12301CE25F55BAF000B2AE0 /* CSActionItem.swift in Sources */,
 				F139D0CC22EA9209007F5C0D /* DpkgWrapper.swift in Sources */,
 				F1A4D8DC231C25FA00149DDF /* Dusk.swift in Sources */,
@@ -3038,6 +3041,7 @@
 				F139D0FB22EA9209007F5C0D /* FeaturedBannerView.swift in Sources */,
 				F12652D725A165340094E446 /* SourcesSplitViewController.swift in Sources */,
 				FBBD0041240C31B4008E11B2 /* NewsArticlesViewController.swift in Sources */,
+				E1EB0366268BA4690097CEE1 /* DownloadsTableViewController.swift in Sources */,
 				F1A116BB2384D57D00B6F408 /* DepictionFontCollection.swift in Sources */,
 				F172581D24EB88E3000F2FAF /* PackageStub.swift in Sources */,
 				F139D0BA22EA9209007F5C0D /* FeaturedBannersView.swift in Sources */,
@@ -3084,8 +3088,10 @@
 				FB6F3D3224AA635F00E941F8 /* PaymentError.swift in Sources */,
 				F1AB912822ED081E0054341B /* PackageIconView.swift in Sources */,
 				F139D0DD22EA9209007F5C0D /* PackageListHeader.swift in Sources */,
+				E1D6DFB8268BA730005BF9EA /* APTJsonParser.swift in Sources */,
 				F139D10D22EA9209007F5C0D /* PackageListManager.swift in Sources */,
 				F1D82F7823094E1C00EECCAE /* PackageListViewController.swift in Sources */,
+				E1EB0363268BA45C0097CEE1 /* DownloadsTableViewCell.swift in Sources */,
 				F14F7D5A240A766D00062310 /* CSTextRenderView.swift in Sources */,
 				F1A116B82384D49500B6F408 /* DepictionColorCollection.swift in Sources */,
 				F172581A24EB848E000F2FAF /* NewsArticle.swift in Sources */,
@@ -3113,7 +3119,6 @@
 				F1AB911F22ED02900054341B /* TabBar.swift in Sources */,
 				F139D0E822EA9209007F5C0D /* UIColor+HTMLColors.m in Sources */,
 				F13AEE6D22F75913004BAA05 /* UIPasteboard+Sources.swift in Sources */,
-				F1FFE5DB23D5145300916364 /* DependencyResolverAccelerator.swift in Sources */,
 				F139D0E222EA9209007F5C0D /* WhiteBlur.m in Sources */,
 				F139D0FF22EA9209007F5C0D /* WishListManager.swift in Sources */,
 				E14C5EBE266687C80080BFCE /* XZ.swift in Sources */,
@@ -3180,6 +3185,7 @@
 				F1C85B47232574F70064D3A2 /* SileoSelectionView.swift in Sources */,
 				F170606224CF54E0001596A0 /* SileoTableViewController.swift in Sources */,
 				F1C85B442325707A0064D3A2 /* SileoTableViewCell.swift in Sources */,
+				E1EB036B268BA4C30097CEE1 /* DependencyResolverAccelerator.swift in Sources */,
 				F1C5D99B22D144790021BD89 /* DepictionSpacerView.swift in Sources */,
 				F1C5D98F22D13AA90021BD89 /* DepictionStackView.swift in Sources */,
 				F1C5D9A522D148540021BD89 /* DepictionSubheaderView.swift in Sources */,
@@ -3195,17 +3201,15 @@
 				F170600124CCC7E6001596A0 /* PackageQueueButton.swift in Sources */,
 				F1C5D9ED22D1ABDC0021BD89 /* DepictionVideoView.swift in Sources */,
 				F1C5D9EA22D1A9270021BD89 /* DepictionWebView.swift in Sources */,
+				E1EB0368268BA4B00097CEE1 /* DownloadManager.swift in Sources */,
 				F13AEE5B22F62B9D004BAA05 /* Download.swift in Sources */,
 				FB6F3D3424AA68A900E941F8 /* PaymentPackageInfo.swift in Sources */,
 				F14F7D5C240A7E7800062310 /* CSTextView.swift in Sources */,
 				F1AB912422ED05B90054341B /* DownloadConfirmButton.swift in Sources */,
-				F13AEE5622F5613C004BAA05 /* DownloadManager.swift in Sources */,
 				F1330EB12325644700971073 /* SileoContentView.swift in Sources */,
 				F13AEE5322F52F98004BAA05 /* DownloadPackage.swift in Sources */,
-				F1AB913322ED133D0054341B /* DownloadsTableViewCell.swift in Sources */,
 				F16115D1244D87CD003BF1E6 /* FeaturedButton.swift in Sources */,
 				E1DC86062669673600B3DC42 /* AmyLogManager.swift in Sources */,
-				F13AEE5E22F63122004BAA05 /* DownloadsTableViewController.swift in Sources */,
 				F1A7051322D0359900F602DA /* DpkgWrapper.swift in Sources */,
 				F107EB62230D195A002B8C20 /* Dusk.swift in Sources */,
 				E1C6C0D82677BFDE006228E0 /* KeychainManager.swift in Sources */,
@@ -3221,6 +3225,7 @@
 				F1A116BA2384D57D00B6F408 /* DepictionFontCollection.swift in Sources */,
 				F1C5D9E122D199900021BD89 /* FeaturedBannersView.swift in Sources */,
 				F1C5D9C622D1879D0021BD89 /* FeaturedBaseView.swift in Sources */,
+				E1EB0365268BA4690097CEE1 /* DownloadsTableViewController.swift in Sources */,
 				F1C5D9E422D1A1140021BD89 /* FeaturedButtonView.swift in Sources */,
 				F1C5D9D522D189AF0021BD89 /* FeaturedHeaderView.swift in Sources */,
 				F1C5D9D822D18B410021BD89 /* FeaturedInfoFooterView.swift in Sources */,
@@ -3267,8 +3272,10 @@
 				F1CA758D244CF813000BA15C /* String+Error.swift in Sources */,
 				F172581924EB848E000F2FAF /* NewsArticle.swift in Sources */,
 				49CE7CB02607F97C00A20711 /* AltIconTableViewCell.swift in Sources */,
+				E1D6DFB7268BA730005BF9EA /* APTJsonParser.swift in Sources */,
 				F147E67622F021560048F868 /* PackageStateBadgeView.swift in Sources */,
 				FB40262923DE87F8002D97FE /* SettingsIconHeaderView.swift in Sources */,
+				E1EB0362268BA45C0097CEE1 /* DownloadsTableViewCell.swift in Sources */,
 				F183CFC7231A563500D3AF3B /* PackageViewController.swift in Sources */,
 				F147E68022F164230048F868 /* PaymentAuthenticationBannerView.swift in Sources */,
 				F1330EA92324F76C00971073 /* UIColor-ThemeColors.swift in Sources */,
@@ -3295,7 +3302,6 @@
 				F1AB911E22ED02900054341B /* TabBar.swift in Sources */,
 				F120234121470F69005EAFAC /* UIColor+HTMLColors.m in Sources */,
 				F13AEE6C22F75913004BAA05 /* UIPasteboard+Sources.swift in Sources */,
-				F1FFE5DA23D5145300916364 /* DependencyResolverAccelerator.swift in Sources */,
 				56A5989D214657BB00677FCA /* WhiteBlur.m in Sources */,
 				F102D1E322CD514C00A4C9BA /* WishListManager.swift in Sources */,
 				56A5989B214657A700677FCA /* ZKSwizzle.m in Sources */,

--- a/Sileo/Backend/APT Wrapper/APTJsonParser.swift
+++ b/Sileo/Backend/APT Wrapper/APTJsonParser.swift
@@ -1,0 +1,237 @@
+//
+//  APTJsonParser.swift
+//  Sileo
+//
+//  Created by Aarnav Tale on 6/28/21.
+//  Copyright © 2021 Sileo Team. All rights reserved.
+//
+
+enum APTParserErrors: Error {
+    case missingSileoConf
+    case blankRequest
+    case failedDataEncoding
+    case blankJsonOutput
+}
+
+struct APTOutput {
+    var operations = [APTOperation]()
+    var conflicts = [APTBrokenPackage]()
+}
+
+// This is for parsing a full JSON Object
+struct RawAPTOutput: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case operations
+        case brokenPackages
+    }
+
+    var operations: [APTOperation]?
+    var brokenPackages: ErrorParserWrapper?
+
+    // This bit above and below are here so that the keys can be optional
+    // Essentially, APT either gives an "operations" or "brokenPackages" key
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.operations = try? values.decodeIfPresent([APTOperation].self, forKey: .operations)
+        self.brokenPackages = try? values.decodeIfPresent(ErrorParserWrapper.self, forKey: .brokenPackages)
+    }
+}
+
+struct APTOperation: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case packageID = "Package"
+        case version = "Version"
+        case type = "Type"
+    }
+
+    enum OperationType: String, Decodable {
+        case install = "Inst"
+        case configure = "Conf"
+        case remove = "Remv"
+        case purge = "Purg"
+    }
+
+    let packageID: String
+    let version: String
+    let type: OperationType
+}
+
+struct APTBrokenPackage: Decodable {
+    struct ConflictingPackage: Decodable {
+
+        // swiftlint:disable nesting
+        enum Conflict: String, Decodable {
+            case preDepends = "Pre-Depends"
+            case recommends = "Recommends"
+            case conflicts = "Conflicts"
+            case replaces = "Replaces"
+            case depends = "Depends"
+        }
+
+        // swiftlint:disable nesting
+        enum CodingKeys: String, CodingKey {
+            case package = "Package"
+            case conflict = "Type"
+        }
+
+        let package: String
+        let conflict: Conflict
+    }
+
+    let packageID: String
+    let conflictingPackages: [ConflictingPackage]
+}
+
+struct ErrorParserWrapper: Decodable {
+    var brokenPackages: [APTBrokenPackage]
+
+    // This allows us to have custom JSON keys
+    // APT returns this for brokenPackages
+    struct PackageIDKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PackageIDKey.self)
+        var brokenPackages = [APTBrokenPackage]()
+
+        for package in container.allKeys {
+            // These are the individual brokenPackages given by APT (It's a double nested array because of the way the JSON patch is)
+            let wrappedConflictingPackages = try container.decode([[APTBrokenPackage.ConflictingPackage]].self, forKey: package)
+
+            // ErrorParserWrapper is merely used to create an APTBrokenPackage
+            // That's why the package is created manually, to prevent unnecessary data nesting
+            for conflictingPackages in wrappedConflictingPackages {
+                let brokenPackage = APTBrokenPackage(packageID: package.stringValue, conflictingPackages: conflictingPackages)
+                brokenPackages.append(brokenPackage)
+            }
+        }
+
+        self.brokenPackages = brokenPackages
+    }
+}
+
+extension APTWrapper {
+    // APT syntax: a- = remove a; b = install b
+    public class func operationList(installList: [DownloadPackage], removeList: [DownloadPackage]) throws -> APTOutput {
+        // Error check stuff
+        guard let configPath = Bundle.main.path(forResource: "sileo-apt", ofType: "conf") else {
+            throw APTParserErrors.missingSileoConf
+        }
+
+        guard !(installList.isEmpty && removeList.isEmpty) else {
+            // What the hell are you passing, requesting an operationList without any packages?
+            throw APTParserErrors.blankRequest
+        }
+
+        let queryArguments = [
+            "-sqf", "--allow-remove-essential", "--allow-change-held-packages",
+            "--allow-downgrades", "-oquiet::NoUpdate=true", "-oApt::Get::HideAutoRemove=true",
+            "-oquiet::NoProgress=true", "-oquiet::NoStatistic=true", "-c", configPath,
+            "-oAcquire::AllowUnsizedPackages=true", "-oAPT::Get::Show-User-Simulation-Note=False",
+            "-oAPT::Format::for-sileo=true", "-oAPT::Format::JSON=true", "install", "--reinstall"
+        ]
+
+        var packageOperations: [String] = []
+        for downloadPackage in installList {
+            // The downloadPackage.package.package is the deb path on local installs
+            // if it has a / that means it's the path which is a local install
+            if downloadPackage.package.package.contains("/") {
+                // APT will take the raw package path for install
+                packageOperations.append(downloadPackage.package.package)
+            } else {
+                // Force the exact version of the package we downloaded from the repository
+                packageOperations.append("\(downloadPackage.package.packageID)=\(downloadPackage.package.version)")
+            }
+        }
+
+        for downloadPackage in removeList {
+            // Adding '-' after the packageID will query for removal
+            packageOperations.append("\(downloadPackage.package.packageID)-")
+        }
+
+        // APT spawn stuff
+        var aptStdout = ""
+
+        (_, aptStdout, _) = spawn(command: CommandPath.aptget, args: ["apt-get"] + queryArguments + packageOperations)
+        let aptJsonOutput = try normalizeAptOutput(rawOutput: aptStdout)
+
+        return aptJsonOutput
+    }
+
+    // We need to take multiple outputs and make it a full JSON object in some cases, while others we can just serialize the full struct
+    private class func normalizeAptOutput(rawOutput: String) throws -> APTOutput {
+        let decoder = JSONDecoder()
+        var aptOutput = APTOutput()
+
+        // Detect what type of JSON output we are working with
+        // If it's separate JSON, we will serialize immediately
+        // If it's a full JSON object, we will parse it later
+        for rawLine in rawOutput.components(separatedBy: "\n") {
+            let cleanLine = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Seperated JSON Objects parsing (Procursus)
+            if cleanLine.hasPrefix("{") && cleanLine.hasSuffix("}") {
+                guard let data = cleanLine.data(using: .utf8) else {
+                    // What the actual hell, oh well..
+                    NSLog("[Sileo] failedDataEncoding, \(cleanLine)")
+                    throw APTParserErrors.failedDataEncoding
+                }
+
+                if let operation = try? decoder.decode(APTOperation.self, from: data) {
+                    aptOutput.operations.append(operation)
+                }
+
+                if let error = try? decoder.decode(ErrorParserWrapper.self, from: data) {
+                    aptOutput.conflicts += error.brokenPackages
+                }
+            }
+        }
+
+        // If there was no decodeable output, we need to parse as one big object (Elucubratus)
+        if aptOutput.conflicts.isEmpty && aptOutput.operations.isEmpty {
+            let cleanOutput = rawOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "\n", with: "")
+
+            // We need a substring of the JSON object only
+            guard let openingBracket = cleanOutput.firstIndex(of: "{"),
+                  let closingBracket = cleanOutput.lastIndex(of: "}") else {
+                NSLog("[Sileo] blankJsonOutput \(cleanOutput)")
+                throw APTParserErrors.blankJsonOutput
+            }
+
+            let jsonObject = cleanOutput[openingBracket..<closingBracket]
+                // These are normalized to have easier JSON parsing
+                .replacingOccurrences(of: "CandidateVersion", with: "Version")
+                .replacingOccurrences(of: "CurrentVersion", with: "Version")
+                .appending("}") // Appended this because we cut it off in our substring
+
+            guard let data = jsonObject.data(using: .utf8) else {
+                NSLog("[Sileo] failedDataEncoding \(jsonObject)")
+                throw APTParserErrors.failedDataEncoding
+            }
+
+            let rawOutput = try decoder.decode(RawAPTOutput.self, from: data)
+
+            if let operations = rawOutput.operations {
+                aptOutput.operations += operations
+            }
+
+            if let parsedError = rawOutput.brokenPackages {
+                aptOutput.conflicts += parsedError.brokenPackages
+            }
+        }
+
+        return aptOutput
+    }
+}

--- a/Sileo/Backend/APT Wrapper/APTWrapper.swift
+++ b/Sileo/Backend/APT Wrapper/APTWrapper.swift
@@ -12,7 +12,7 @@ class APTWrapper {
     static let sileoFD = 6
     static let cydiaCompatFd = 6
     static let debugFD = 11
-    
+
     public enum FINISH: Int {
         case back = 0,
         uicache = 1,
@@ -21,7 +21,7 @@ class APTWrapper {
         reload = 4,
         reboot = 5
     }
-    
+
     static let GNUPGPREFIX = "[GNUPG:]"
     static let GNUPGBADSIG = "[GNUPG:] BADSIG"
     static let GNUPGERRSIG = "[GNUPG:] ERRSIG"
@@ -34,18 +34,18 @@ class APTWrapper {
     static let GNUPGNODATA = "[GNUPG:] NODATA"
     static let APTKEYWARNING = "[APTKEY:] WARNING"
     static let APTKEYERROR = "[APTKEY:] ERROR"
-    
+
     enum DigestState {
         case untrusted,
         weak,
         trusted
     }
-    
+
     struct Digest {
         let state: DigestState
         let name: String
     }
-    
+
     static let digests: [Digest] = [
         Digest(state: .untrusted, name: "Invalid Digest"),
         Digest(state: .untrusted, name: "MD5"),
@@ -60,154 +60,28 @@ class APTWrapper {
         Digest(state: .trusted, name: "SHA512"),
         Digest(state: .trusted, name: "SHA224")
     ]
-    
+
     class func dictionaryOfScannedApps() -> [String: Int64] {
         var dictionary: [String: Int64] = [:]
         let fileManager = FileManager.default
-        
+
         guard let apps = try? fileManager.contentsOfDirectory(atPath: "/Applications") else {
             return dictionary
         }
-        
+
         for app in apps {
             let infoPlist = String(format: "/Applications/%@/Info.plist", app)
-            
+
             guard let attr = try? fileManager.attributesOfItem(atPath: infoPlist) else {
                 continue
             }
-            
+
             let fileNumber = attr[FileAttributeKey.systemFileNumber] as? Int64
             dictionary[app] = fileNumber
         }
         return dictionary
     }
-    
-    // APT syntax: a- = remove a; b = install b
-    public class func packageOperations(installs: [DownloadPackage], removals: [DownloadPackage]) throws -> [String: [[String: Any]]] {
-        var arguments = ["-sqf", "--allow-remove-essential", "--allow-change-held-packages",
-                         "--allow-downgrades", "-oquiet::NoUpdate=true",
-                         "-oApt::Get::HideAutoRemove=true", "-oquiet::NoProgress=true",
-                         "-oquiet::NoStatistic=true", "-c", Bundle.main.path(forResource: "sileo-apt", ofType: "conf") ?? "",
-                         "-oAcquire::AllowUnsizedPackages=true", "-oAPT::Get::Show-User-Simulation-Note=False",
-                         "-oAPT::Format::for-sileo=true", "install", "--reinstall"]
-        for package in installs {
-            if package.package.package.contains("/") {
-                arguments.append(package.package.package)
-            } else {
-                arguments.append(package.package.package + "=" + package.package.version)
-            }
-        }
-        for package in removals {
-            arguments.append(package.package.package + "-")
-        }
-        
-        var aptOutput = ""
-        var aptErrorOutput = ""
-        
-        #if targetEnvironment(simulator) || TARGET_SANDBOX
-        if installs.count + removals.count > 1 {
-            fatalError("Only have sample data for at most 1 package, sorry :(")
-        }
-        // swiftlint:disable line_length
-        if !installs.isEmpty && installs[0].package.package == "org.coolstar.betterpowerdown" {
-            aptOutput = "{\"Type\":\"Inst\",\"Package\":\"org.coolstar.libclassictelephonyui\",\"Version\":\"1.2-3\",\"Release\":\"BigBoss+:0.9/stable [iphoneos-arm]\"}\n{\"Type\":\"Inst\",\"Package\":\"org.coolstar.betterpowerdown\",\"Version\":\"1.4.0\",\"Release\":\"BigBoss+:0.9/stable [iphoneos-arm]\"}"
-        } else if !installs.isEmpty && installs[0].package.package == "com.ikilledappl3.sareth" {
-            aptOutput = "Some packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n{\"com.ikilledappl3.sareth\":[[{\"Reason\":\"11.3.1 is to be installed\",\"Package\":\"firmware\",\"Type\":\"Depends\",\"VersionSummary\":\">= 12.0\"}]]}"
-            aptErrorOutput = "E: Unable to correct problems, you have held broken packages."
-        } else if !removals.isEmpty && removals[0].package.package == "bash" {
-            aptOutput = "{\"Type\":\"Remv\",\"Package\":\"cydia-lproj\",\"Version\":\"1.1.12\"}\n{\"Type\":\"Remv\",\"Package\":\"cydia\",\"Version\":\"2.0-sileo\"}\n{\"Type\":\"Remv\",\"Package\":\"org.coolstar.sileo\",\"Version\":\"0.1b6\"}\n{\"Type\":\"Remv\",\"Package\":\"apt7\",\"Version\":\"1.4.8\"}\n{\"Type\":\"Remv\",\"Package\":\"apt7-key\",\"Version\":\"1.4.8\"}\n{\"Type\":\"Remv\",\"Package\":\"apt7-lib\",\"Version\":\"1.4.8-1\"}\n{\"Type\":\"Remv\",\"Package\":\"base\",\"Version\":\"1-4\"}\n{\"Type\":\"Remv\",\"Package\":\"com.linusyang.localeutf8\",\"Version\":\"1.0-1\"}\n{\"Type\":\"Remv\",\"Package\":\"coreutils\",\"Version\":\"8.29-1\"}\n{\"Type\":\"Remv\",\"Package\":\"profile.d\",\"Version\":\"0-2\"}\n{\"Type\":\"Remv\",\"Package\":\"system-cmds\",\"Version\":\"790\"}\n{\"Type\":\"Remv\",\"Package\":\"firmware-sbin\",\"Version\":\"0-1\"}\n{\"Type\":\"Remv\",\"Package\":\"dpkg\",\"Version\":\"1.18.24\"}\n{\"Type\":\"Remv\",\"Package\":\"findutils\",\"Version\":\"4.6\"}\n{\"Type\":\"Remv\",\"Package\":\"bash\",\"Version\":\"4.4.18\"}\n{\"Type\":\"Remv\",\"Package\":\"berkeleydb\",\"Version\":\"6.2.23\"}\n{\"Type\":\"Remv\",\"Package\":\"com.tigisoftware.filza\",\"Version\":\"3.5.2-1\"}\n{\"Type\":\"Remv\",\"Package\":\"curl\",\"Version\":\"7.59.0-1\"}\n{\"Type\":\"Remv\",\"Package\":\"darwintools\",\"Version\":\"1-6\"}\n{\"Type\":\"Remv\",\"Package\":\"debianutils\",\"Version\":\"4.8.4\"}\n{\"Type\":\"Remv\",\"Package\":\"gnupg\",\"Version\":\"1.4.22\"}\n{\"Type\":\"Remv\",\"Package\":\"tar\",\"Version\":\"1.30\"}\n{\"Type\":\"Remv\",\"Package\":\"lzma\",\"Version\":\"5.2.3\"}\n{\"Type\":\"Remv\",\"Package\":\"gzip\",\"Version\":\"1.8\"}\n{\"Type\":\"Remv\",\"Package\":\"grep\",\"Version\":\"3.1\"}\n{\"Type\":\"Remv\",\"Package\":\"nano\",\"Version\":\"2.9.7\"}\n{\"Type\":\"Remv\",\"Package\":\"vim\",\"Version\":\"8.0.1848\"}\n{\"Type\":\"Remv\",\"Package\":\"ncurses\",\"Version\":\"6.1\"}\n{\"Type\":\"Remv\",\"Package\":\"nghttp2\",\"Version\":\"1.31.0\"}\n{\"Type\":\"Remv\",\"Package\":\"openssh\",\"Version\":\"7.6p1-4\"}\n{\"Type\":\"Remv\",\"Package\":\"org.coolstar.cctools\",\"Version\":\"895\"}\n{\"Type\":\"Remv\",\"Package\":\"wget\",\"Version\":\"1.19\"}\n{\"Type\":\"Remv\",\"Package\":\"openssl\",\"Version\":\"1.0.2n\"}\n{\"Type\":\"Remv\",\"Package\":\"sed\",\"Version\":\"4.2.2\"}\n{\"Type\":\"Remv\",\"Package\":\"shell-cmds\",\"Version\":\"203\"}\n{\"Type\":\"Remv\",\"Package\":\"socat\",\"Version\":\"1.7.2.3\"}"
-        } else if !installs.isEmpty || !removals.isEmpty {
-            fatalError("Package ID doesn't match sample data (org.coolstar.betterpowerdown, com.ikilledappl3.sareth, or bash).")
-        }
-        // swiftlint:enable line_length
-        #else
-        if installs.isEmpty && removals.isEmpty {
-            aptOutput = ""
-        } else {
-            (_, aptOutput, aptErrorOutput) = spawn(command: CommandPath.aptget, args: ["apt-get"] + arguments)
-        }
-        #endif
-        
-        var packageOperations: [String: [[String: Any]]] = [:]
-        var packageInstalls: [[String: String]] = []
-        var packageRemovals: [[String: String]] = []
-        var packageErrors: [[String: Any]] = []
-        
-        let aptLines = aptOutput.components(separatedBy: "\n")
-        for aptLine in aptLines {
-            if aptLine == "The following packages have unmet dependencies:" {
-                break
-            }
-            if aptLine.hasPrefix("{") && aptLine.hasSuffix("}") {
-                guard let aptOp = try? JSONSerialization.jsonObject(with: aptLine.data(using: .utf8) ?? Data(),
-                                                                    options: []) as? [String: String] else {
-                    continue
-                }
-                if let type = aptOp["Type"],
-                    let packageID = aptOp["Package"],
-                    let version = aptOp["Version"] {
-                    if type == "Inst"{
-                        packageInstalls.append([
-                            "package": packageID,
-                            "version": version
-                        ])
-                    } else if type == "Remv" || type == "Purg" {
-                        packageRemovals.append([
-                            "package": packageID,
-                            "version": version
-                        ])
-                    }
-                }
-            }
-        }
-        packageOperations["Inst"] = packageInstalls
-        packageOperations["Remv"] = packageRemovals
-        
-        let aptErrorLines = aptOutput.components(separatedBy: "\n")
-        
-        var isDependencies = false
-        
-        for aptErrorLine in aptErrorLines {
-            if !isDependencies {
-                if aptErrorLine == "The following packages have unmet dependencies:" {
-                    isDependencies = true
-                    continue
-                }
-            } else {
-                if aptErrorLine.isEmpty {
-                    continue
-                } else {
-                    if aptErrorLine.hasPrefix("{") && aptErrorLine.hasSuffix("}") {
-                        guard let dependencyOutput = try? JSONSerialization.jsonObject(with: aptErrorLine.data(using: .utf8) ?? Data(),
-                                                                                       options: []) as? [String: [[[String: String]]]] else {
-                            continue
-                        }
-                        for (packageID, dependencyCandidateLists) in dependencyOutput {
-                            guard let package = PackageListManager.shared.newestPackage(identifier: packageID, repoContext: nil) else {
-                                continue
-                            }
-                            for dependencyCandidateList in dependencyCandidateLists {
-                                for dependency in dependencyCandidateList {
-                                    if let dependencyType = dependency["Type"],
-                                        let dependencyPackage = dependency["Package"] {
-                                        packageErrors.append([
-                                            "package": package,
-                                            "key": dependencyType,
-                                            "otherPkg": dependencyPackage
-                                        ])
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        
-        packageOperations["Err"] = packageErrors
-        return packageOperations
-    }
-    
+
     public class func installProgress(aptStatus: String) -> (Bool, Double, String) {
         let statusParts = aptStatus.components(separatedBy: ":")
         if statusParts.count < 4 {
@@ -216,33 +90,33 @@ class APTWrapper {
         if statusParts[0] != "pmstatus" {
             return (false, 0, "")
         }
-        
+
         // let packageName = statusParts[1]
-        
+
         guard let rawProgress = Double(statusParts[2]) else {
             return (false, 0, "")
         }
         let statusReadable = statusParts[3]
         return (true, rawProgress, statusReadable)
     }
-    
+
     public class func verifySignature(key: String, data: String, error: inout String) -> Bool {
         #if targetEnvironment(simulator) || TARGET_SANDBOX
-        
+
         error = "GnuPG not available in sandboxed environment"
         return false
-        
+
         #else
-        
+
         let (_, output, _) = spawn(command: CommandPath.sh, args: ["sh", CommandPath.aptkey, "verify", "-q", "--status-fd", "1", key, data])
-        
+
         let outputLines = output.components(separatedBy: "\n")
-        
+
         var keyIsGood = false
         var keyIsTrusted = false
-        
+
         let substrCount = GNUPGPREFIX.count + 1
-        
+
         for outputLine in outputLines {
             for prefix in [GNUPGBADSIG, GNUPGERRSIG, GNUPGEXPSIG, GNUPGREVKEYSIG, GNUPGNOPUBKEY, GNUPGNODATA] {
                 if outputLine.hasPrefix(prefix) {
@@ -259,15 +133,15 @@ class APTWrapper {
                 if sigComponents.count < 10 {
                     continue
                 }
-                
+
                 // let sig = sigComponents[2]
                 let digestType = sigComponents[9]
-                
+
                 guard let digestIdx = Int(digestType),
                     digestIdx <= digests.count else {
                         continue
                 }
-                
+
                 let digest = digests[digestIdx]
                 if digest.state == .trusted {
                     keyIsTrusted = true
@@ -275,10 +149,10 @@ class APTWrapper {
             }
         }
         return keyIsGood && keyIsTrusted
-        
+
         #endif
     }
-    
+
     public class func performOperations(installs: [DownloadPackage],
                                         removals: [DownloadPackage],
                                         progressCallback: @escaping (Double, Bool, String) -> Void,
@@ -287,7 +161,7 @@ class APTWrapper {
         guard let giveMeRootPath = Bundle.main.path(forAuxiliaryExecutable: "giveMeRoot") else {
             fatalError("Unable to find giveMeRoot")
         }
-        
+
         var arguments = [CommandPath.aptget, "install", "--reinstall", "--allow-unauthenticated", "--allow-downgrades",
                         "--no-download", "--allow-remove-essential", "--allow-change-held-packages",
                          "-c", Bundle.main.path(forResource: "sileo-apt", ofType: "conf") ?? "",
@@ -304,22 +178,22 @@ class APTWrapper {
             let packageStr = package.package.package + "-"
             arguments.append(packageStr)
         }
-        
+
         DispatchQueue.global(qos: .default).async {
             var oldApps = APTWrapper.dictionaryOfScannedApps()
-            
+
             var pipestatusfd: [Int32] = [0, 0]
             var pipestdout: [Int32] = [0, 0]
             var pipestderr: [Int32] = [0, 0]
             var pipesileo: [Int32] = [0, 0]
-            
+
             let bufsiz = Int(BUFSIZ)
-            
+
             pipe(&pipestdout)
             pipe(&pipestderr)
             pipe(&pipestatusfd)
             pipe(&pipesileo)
-            
+
             guard fcntl(pipestdout[0], F_SETFL, O_NONBLOCK) != -1,
                   fcntl(pipestderr[0], F_SETFL, O_NONBLOCK) != -1,
                   fcntl(pipestatusfd[0], F_SETFL, O_NONBLOCK) != -1,
@@ -327,7 +201,7 @@ class APTWrapper {
             else {
                 fatalError("Unable to set attributes on pipe")
             }
-            
+
             var fileActions: posix_spawn_file_actions_t?
             posix_spawn_file_actions_init(&fileActions)
             posix_spawn_file_actions_addclose(&fileActions, pipestdout[0])
@@ -342,16 +216,16 @@ class APTWrapper {
             posix_spawn_file_actions_addclose(&fileActions, pipestderr[1])
             posix_spawn_file_actions_addclose(&fileActions, pipestatusfd[1])
             posix_spawn_file_actions_addclose(&fileActions, pipesileo[1])
-            
+
             arguments.insert("giveMeRoot", at: 0)
-            
+
             let argv: [UnsafeMutablePointer<CChar>?] = arguments.map { $0.withCString(strdup) }
             defer {
                 for case let arg? in argv {
                     free(arg)
                 }
             }
-            
+
             let environment = ["SILEO=6 1", "CYDIA=6 1"]
             let env: [UnsafeMutablePointer<CChar>?] = environment.map { $0.withCString(strdup) }
             defer {
@@ -359,35 +233,35 @@ class APTWrapper {
                     free(key)
                 }
             }
-            
+
             var pid: pid_t = 0
-            
+
             let spawnStatus = posix_spawn(&pid, giveMeRootPath, &fileActions, nil, argv + [nil], env + [nil])
             if spawnStatus != 0 {
                 return
             }
-            
+
             close(pipestdout[1])
             close(pipestderr[1])
             close(pipestatusfd[1])
             close(pipesileo[1])
-            
+
             var finish = FINISH.back
             var runUICache = false
-            
+
             let mutex = DispatchSemaphore(value: 0)
-            
+
             let readQueue = DispatchQueue(label: "org.coolstar.sileo.command",
                                           qos: .userInitiated,
                                           attributes: .concurrent,
                                           autoreleaseFrequency: .inherit,
                                           target: nil)
-            
+
             let stdoutSource = DispatchSource.makeReadSource(fileDescriptor: pipestdout[0], queue: readQueue)
             let stderrSource = DispatchSource.makeReadSource(fileDescriptor: pipestderr[0], queue: readQueue)
             let statusFdSource = DispatchSource.makeReadSource(fileDescriptor: pipestatusfd[0], queue: readQueue)
             let sileoFdSource = DispatchSource.makeReadSource(fileDescriptor: pipesileo[0], queue: readQueue)
-            
+
             stdoutSource.setCancelHandler {
                 close(pipestdout[0])
                 mutex.signal()
@@ -403,21 +277,21 @@ class APTWrapper {
             sileoFdSource.setCancelHandler {
                 close(pipesileo[0])
             }
-            
+
             stdoutSource.setEventHandler {
                 let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufsiz)
                 defer { buffer.deallocate() }
-                
+
                 let bytesRead = read(pipestdout[0], buffer, bufsiz)
                 guard bytesRead > 0 else {
                     if bytesRead == -1 && errno == EAGAIN {
                         return
                     }
-                    
+
                     stdoutSource.cancel()
                     return
                 }
-                
+
                 let array = Array(UnsafeBufferPointer(start: buffer, count: bytesRead)) + [UInt8(0)]
                 array.withUnsafeBufferPointer { ptr in
                     let str = String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
@@ -427,17 +301,17 @@ class APTWrapper {
             stderrSource.setEventHandler {
                 let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufsiz)
                 defer { buffer.deallocate() }
-                
+
                 let bytesRead = read(pipestderr[0], buffer, bufsiz)
                 guard bytesRead > 0 else {
                     if bytesRead == -1 && errno == EAGAIN {
                         return
                     }
-                    
+
                     stderrSource.cancel()
                     return
                 }
-                
+
                 let array = Array(UnsafeBufferPointer(start: buffer, count: bytesRead)) + [UInt8(0)]
                 array.withUnsafeBufferPointer { ptr in
                     let str = String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
@@ -447,21 +321,21 @@ class APTWrapper {
             statusFdSource.setEventHandler {
                 let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufsiz)
                 defer { buffer.deallocate() }
-                
+
                 let bytesRead = read(pipestatusfd[0], buffer, bufsiz)
                 guard bytesRead > 0 else {
                     if bytesRead == -1 && errno == EAGAIN {
                         return
                     }
-                    
+
                     statusFdSource.cancel()
                     return
                 }
-                
+
                 let array = Array(UnsafeBufferPointer(start: buffer, count: bytesRead)) + [UInt8(0)]
                 array.withUnsafeBufferPointer { ptr in
                     let str = String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
-                    
+
                     let statusLines = str.components(separatedBy: "\n")
                     for status in statusLines {
                         let (statusValid, statusProgress, statusReadable) = self.installProgress(aptStatus: status)
@@ -472,21 +346,21 @@ class APTWrapper {
             sileoFdSource.setEventHandler {
                 let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufsiz)
                 defer { buffer.deallocate() }
-                
+
                 let bytesRead = read(pipesileo[0], buffer, bufsiz)
                 guard bytesRead > 0 else {
                     if bytesRead == -1 && errno == EAGAIN {
                         return
                     }
-                    
+
                     statusFdSource.cancel()
                     return
                 }
-                
+
                 let array = Array(UnsafeBufferPointer(start: buffer, count: bytesRead)) + [UInt8(0)]
                 array.withUnsafeBufferPointer { ptr in
                     let str = String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
-                    
+
                     let sileoLines = str.components(separatedBy: "\n")
                     for sileoLine in sileoLines {
                         if sileoLine.hasPrefix("finish:") {
@@ -510,7 +384,7 @@ class APTWrapper {
                             if sileoLine.hasPrefix("finish:reboot") {
                                 newFinish = .reboot
                             }
-                            
+
                             if newFinish.rawValue > finish.rawValue {
                                 finish = newFinish
                             }
@@ -518,40 +392,40 @@ class APTWrapper {
                     }
                 }
             }
-            
+
             stdoutSource.resume()
             stderrSource.resume()
             statusFdSource.resume()
             sileoFdSource.resume()
-            
+
             mutex.wait()
             mutex.wait()
             mutex.wait()
-            
+
             if !sileoFdSource.isCancelled {
                 sileoFdSource.cancel()
             }
-            
+
             var status: Int32 = 0
             waitpid(pid, &status, 0)
-            
+
             var refreshSileo = false
             if runUICache {
                 progressCallback(99, true, "Updating icon cache...")
                 outputCallback("Updating Icon Cache\n", debugFD)
-                
+
                 var newApps = dictionaryOfScannedApps()
-                
+
                 for key in oldApps.keys where oldApps[key] == newApps[key] {
                     oldApps.removeValue(forKey: key)
                     newApps.removeValue(forKey: key)
                 }
-                
+
                 for key in newApps.keys where oldApps[key] == newApps[key] {
                     oldApps.removeValue(forKey: key)
                     newApps.removeValue(forKey: key)
                 }
-                
+
                 let diff = newApps.merging(oldApps) { current, _ in current }
                 for appName in diff.keys {
                     let appPath = URL(fileURLWithPath: "/Applications/").appendingPathComponent(appName)

--- a/Sileo/Backend/Dependency Resolver/DependencyResolverAccelerator.swift
+++ b/Sileo/Backend/Dependency Resolver/DependencyResolverAccelerator.swift
@@ -25,7 +25,7 @@ class DependencyResolverAccelerator {
         #if targetEnvironment(simulator) || TARGET_SANDBOX
         #else
         spawnAsRoot(args: [CommandPath.mkdir, "-p", CommandPath.sileolists])
-        spawnAsRoot(args: [CommandPath.chown, "-R", "mobile:mobile", CommandPath.sileolists])
+        spawnAsRoot(args: [CommandPath.chown, "-R", CommandPath.group, CommandPath.sileolists])
         spawnAsRoot(args: [CommandPath.chmod, "-R", "0755", CommandPath.sileolists])
         #endif
         
@@ -90,7 +90,16 @@ class DependencyResolverAccelerator {
                 guard let packageData = package.rawData else {
                     continue
                 }
-                sourcesData.append(packageData)
+                var string = String(decoding: packageData, as: UTF8.self)
+                if string.suffix(2) != "\n\n" {
+                    if string.last == "\n" {
+                        string += "\n"
+                    } else {
+                        string += "\n\n"
+                    }
+                }
+                guard let data = string.data(using: .utf8) else { continue }
+                sourcesData.append(data)
             }
             do {
                 try sourcesData.write(to: newSourcesFile.aptUrl)

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -1071,8 +1071,8 @@ final class RepoManager {
             DatabaseManager.shared.saveQueue()
             
             DispatchQueue.main.async {
-                DownloadManager.shared.repoRefresh()
                 if reposUpdated > 0 {
+                    DownloadManager.shared.repoRefresh()
                     DependencyResolverAccelerator.shared.preflightInstalled()
                     DownloadManager.shared.repoRefresh()
                     NotificationCenter.default.post(name: PackageListManager.reloadNotification, object: nil)

--- a/Sileo/Backend/Root Wrapper/RootWrapper.swift
+++ b/Sileo/Backend/Root Wrapper/RootWrapper.swift
@@ -363,4 +363,12 @@ public class CommandPath {
         return ""
         #endif
     }
+    
+    static var group: String {
+        #if targetEnvironment(macCatalyst)
+        return "\(NSUserName()):staff"
+        #else
+        return "mobile:mobile"
+        #endif
+    }
 }

--- a/Sileo/UI/DownloadsViewController/DownloadCell/DownloadsTableViewCell.swift
+++ b/Sileo/UI/DownloadsViewController/DownloadCell/DownloadsTableViewCell.swift
@@ -114,6 +114,7 @@ class DownloadsTableViewCell: BaseSubtitleTableViewCell {
         
         self.selectionStyle = .none
         self.contentView.addSubview(retryButton)
+        self.detailTextLabel?.adjustsFontSizeToFitWidth = true
         retryButton.translatesAutoresizingMaskIntoConstraints = false
         retryButton.heightAnchor.constraint(equalToConstant: 17.5).isActive = true
         retryButton.widthAnchor.constraint(equalToConstant: 17.5).isActive = true

--- a/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
+++ b/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
@@ -23,7 +23,7 @@ class DownloadsTableViewController: SileoViewController {
     var uninstallations: [DownloadPackage] = []
     var installdeps: [DownloadPackage] = []
     var uninstalldeps: [DownloadPackage] = []
-    var errors: [[String: Any]] = []
+    var errors: [APTBrokenPackage] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -248,14 +248,14 @@ extension DownloadsTableViewController: UITableViewDataSource {
         if indexPath.section == 3 {
             // Error listing
             let error = errors[indexPath.row]
-            if let package = error["package"] as? Package {
-                cell.package = DownloadPackage(package: package)
+            let package = Package(package: error.packageID, version: "-1")
+            cell.package = DownloadPackage(package: package)
+            cell.title = error.packageID
+            var description = ""
+            for (index, conflict) in error.conflictingPackages.enumerated() {
+                description += "\(conflict.conflict.rawValue) \(conflict.package)\(index == error.conflictingPackages.count - 1 ? "" : ", ")"
             }
-            cell.shouldHaveDownload = false
-            if let key = error["key"] as? String,
-                let otherPkg = error["otherPkg"] as? String {
-                cell.errorDescription = "\(key) \(otherPkg)"
-            }
+            cell.errorDescription = description
             cell.download = nil
         } else {
             // Normal operation listing

--- a/Sileo/UI/TabBarController/TabBarController.swift
+++ b/Sileo/UI/TabBarController/TabBarController.swift
@@ -274,14 +274,7 @@ class TabBarController: UITabBarController, UITabBarControllerDelegate {
             return
         }
         let alertController = UIAlertController(title: String(localizationKey: "Unknown", type: .error), message: error.localizedDescription, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: String(localizationKey: "Refresh"), style: .default) { _ in
-            if let tabBarController = UIApplication.shared.windows.first?.rootViewController as? UITabBarController,
-               let sourcesSVC = tabBarController.viewControllers?[2] as? UISplitViewController,
-               let sourcesNavNV = sourcesSVC.viewControllers[0] as? SileoNavigationController,
-               let sourcesVC = sourcesNavNV.viewControllers[0] as? SourcesViewController {
-                sourcesVC.refreshSources(forceUpdate: false, forceReload: false, isBackground: true, useRefreshControl: false, useErrorScreen: false, completion: nil)
-            }
-        })
+        alertController.addAction(UIAlertAction(title: String(localizationKey: "OK"), style: .default))
         self.present(alertController, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
The current implementation of `APTWrapper.packageOperations` in the backend has many issues. It doesn't have strict codable types, it's slow, and it's only built to support APT output given by Procursus. As a result, I've implemented a new system, one that properly leverages Decodables to parse the JSON output returned by APT.

This brings performance improvements over the older system and it also results in a cleaner implementation of the `DownloadManager`. There is no longer a need to check for keys that may or may not exist on the output of the `packageOperations` function because of the new `APTWrapper.operationList`, which returns a struct.

Another hidden benefit is the built-in support for both separated JSON (Procursus) and a full JSON object (Elucubratus), helping Sileo reach one of its goals of officially working on both prominent jailbreaking bootstraps in the community at this time.