### PR TITLE
Officially add support for the Elucubratus bootstrap to Sileo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ BETA          ?= 0
 # Build Nightly or not?
 NIGHTLY       ?= 0
 
+# Build for Elucubratus or not?
+ELU_BUILD     ?= 0
+
 TARGET_CODESIGN = $(shell which ldid)
 
 # Platform to build for.
@@ -15,10 +18,16 @@ ifeq ($(SILEO_PLATFORM),iphoneos-arm64)
 ARCH            = arm64
 PLATFORM        = iphoneos
 DEB_ARCH        = iphoneos-arm
-DEB_DEPENDS     = firmware (>= 11.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.31-1), dpkg (>= 1.19.7-2), apt (>= 1.8.2), libzstd1
 PREFIX          =
 DESTINATION     =
 CONTENTS        =
+
+ifeq ($(ELU_BUILD), 1)
+DEB_DEPENDS     = firmware (>= 11.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.32-4), dpkg (>= 1.20.0), apt (>= 2.3.0), libzstd1
+else
+DEB_DEPENDS     = firmware (>= 11.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.31-1), dpkg (>= 1.19.7-2), apt (>= 1.8.2), libzstd1
+endif
+
 else ifeq ($(SILEO_PLATFORM),darwin-arm64)
 # These trues are temporary
 ARCH            = arm64
@@ -111,14 +120,13 @@ else
 BUILD_CONFIG  := Release
 endif
 
-ifeq ($(MAC), 1)
-# Only use ZSTD for the deb package if we are targeting mac
-ifeq ($(shell dpkg-deb --help | grep -qi "zstd" && echo 1),1)
-DPKG_TYPE ?= zstd
-endif
-endif
-
+ifeq ($(ELU_BUILD), 1)
 DPKG_TYPE ?= xz
+else ifeq ($(shell dpkg-deb --help | grep -qi "zstd" && echo 1),1)
+DPKG_TYPE ?= zstd
+else
+DPKG_TYPE ?= xz
+endif
 
 giveMeRoot/bin/giveMeRoot: giveMeRoot/giveMeRoot.c
 	$(MAKE) -C giveMeRoot \
@@ -188,9 +196,29 @@ package: stage
 	@rm -f $(SILEO_STAGE_DIR)/DEBIAN/control.in
 	@mkdir -p ./packages
 	@dpkg-deb -Z$(DPKG_TYPE) --root-owner-group -b $(SILEO_STAGE_DIR) ./packages/$(SILEO_ID)_$(SILEO_VERSION)_$(DEB_ARCH).deb
+else ifeq ($(ELU_BUILD), 1)
+package: stage
+	@cp -a ./layout/DEBIAN $(SILEO_STAGE_DIR)
+	@mv $(SILEO_STAGE_DIR)/DEBIAN/postinst.elu.in $(SILEO_STAGE_DIR)/DEBIAN/postinst.in
+	@mv $(SILEO_STAGE_DIR)/DEBIAN/triggers.elu $(SILEO_STAGE_DIR)/DEBIAN/triggers
+	@sed -e s/@@MARKETING_VERSION@@/$(SILEO_VERSION)/ \
+		-e 's/@@PACKAGE_ID@@/$(SILEO_ID)/' \
+		-e 's/@@PACKAGE_NAME@@/$(SILEO_NAME)/' \
+		-e 's/@@DEB_ARCH@@/$(DEB_ARCH)/' \
+		-e 's/@@ICON@@/$(ICON)/' \
+		-e 's/@@DEB_DEPENDS@@/$(DEB_DEPENDS)/' $(SILEO_STAGE_DIR)/DEBIAN/control.in > $(SILEO_STAGE_DIR)/DEBIAN/control
+	@rm -f $(SILEO_STAGE_DIR)/DEBIAN/control.in
+	@sed -e s/@@SILEO_APP@@/$(SILEO_APP)/ \
+		$(SILEO_STAGE_DIR)/DEBIAN/postinst.in > $(SILEO_STAGE_DIR)/DEBIAN/postinst
+	@chmod 0755 $(SILEO_STAGE_DIR)/DEBIAN/postinst
+	@rm -f $(SILEO_STAGE_DIR)/DEBIAN/postinst.in
+	@mkdir -p ./packages
+	@dpkg-deb -Z$(DPKG_TYPE) --root-owner-group -b $(SILEO_STAGE_DIR) ./packages/$(SILEO_ID)_$(SILEO_VERSION)_$(DEB_ARCH).deb
 else
 package: stage
 	@cp -a ./layout/DEBIAN $(SILEO_STAGE_DIR)
+	@rm -rf $(SILEO_STAGE_DIR)/DEBIAN/postinst.elu.in
+	@rm -rf $(SILEO_STAGE_DIR)/DEBIAN/triggers.elu
 	@sed -e s/@@MARKETING_VERSION@@/$(SILEO_VERSION)/ \
 		-e 's/@@PACKAGE_ID@@/$(SILEO_ID)/' \
 		-e 's/@@PACKAGE_NAME@@/$(SILEO_NAME)/' \

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ ifeq ($(SILEO_PLATFORM),iphoneos-arm64)
 ARCH            = arm64
 PLATFORM        = iphoneos
 DEB_ARCH        = iphoneos-arm
-DEB_DEPENDS     = firmware (>= 11.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.32-4), dpkg (>= 1.20.0), apt (>= 2.3.0), libzstd1
+DEB_DEPENDS     = firmware (>= 11.0), firmware (>= 12.2) | org.swift.libswift (>= 5.0), coreutils (>= 8.31-1), dpkg (>= 1.19.7-2), apt (>= 1.8.2), libzstd1
 PREFIX          =
 DESTINATION     =
-CONTENTS        = 
+CONTENTS        =
 else ifeq ($(SILEO_PLATFORM),darwin-arm64)
 # These trues are temporary
 ARCH            = arm64
@@ -111,15 +111,18 @@ else
 BUILD_CONFIG  := Release
 endif
 
+ifeq ($(MAC), 1)
+# Only use ZSTD for the deb package if we are targeting mac
 ifeq ($(shell dpkg-deb --help | grep -qi "zstd" && echo 1),1)
 DPKG_TYPE ?= zstd
-else
-DPKG_TYPE ?= xz
 endif
+endif
+
+DPKG_TYPE ?= xz
 
 giveMeRoot/bin/giveMeRoot: giveMeRoot/giveMeRoot.c
 	$(MAKE) -C giveMeRoot \
-		CC="xcrun -sdk $(PLATFORM) cc -arch $(ARCH)" 
+		CC="xcrun -sdk $(PLATFORM) cc -arch $(ARCH)"
 
 ifeq ($(MAC), 1)
 $(SILEO_APP_DIR):
@@ -172,7 +175,7 @@ stage: all
 	@$(TARGET_CODESIGN) -SSileo/Sileo.entitlements $(SILEO_STAGE_DIR)/$(PREFIX)/Applications/$(SILEO_APP)/Contents/Plugins/SileoRootWrapper.bundle/Contents/MacOS/SileoRootWrapper
 	@$(TARGET_CODESIGN) -SSileo/Sileo.entitlements $(SILEO_STAGE_DIR)/$(PREFIX)/Applications/$(SILEO_APP)/Contents/Plugins/SileoRootWrapper.bundle/Contents/Resources/giveMeRoot
 endif
-	
+
 ifeq ($(MAC), 1)
 package: stage
 	@cp -a ./layout/DEBIAN $(SILEO_STAGE_DIR)

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -162,7 +162,6 @@ final class RepoManager {
             }
             
             guard !hasRepo(with: normalizedURL),
-                  normalizedURL.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
                   normalizedURL.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false
             else {
                 continue
@@ -199,7 +198,6 @@ final class RepoManager {
         }
         
         guard !hasRepo(with: normalizedURL),
-              normalizedURL.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
               normalizedURL.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false
         else {
             return nil
@@ -285,8 +283,7 @@ final class RepoManager {
         }
         
         for repoURL in uris {
-            guard !repoURL.localizedCaseInsensitiveContains("apt.bingner.com"),
-                  !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
+            guard !repoURL.localizedCaseInsensitiveContains("repo.chariz.io"),
                   !hasRepo(with: URL(string: repoURL)!)
             else {
                 continue

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -10,7 +10,8 @@ import Foundation
 
 // swiftlint:disable:next type_body_length
 final class RepoManager {
-    
+    // This check is here because it's used in multiple places throughout the code
+    private final let isProcursus = FileManager.default.fileExists(atPath: "/etc/apt/trusted.gpg.d/memo.gpg")
     static let progressNotification = Notification.Name("SileoRepoManagerProgress")
     private var repoDatabase = DispatchQueue(label: "org.coolstar.SileoStore.repo-database")
     
@@ -162,7 +163,11 @@ final class RepoManager {
             }
             
             guard !hasRepo(with: normalizedURL),
-                  normalizedURL.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false
+                  // Prevent cross adding when using a certain bootstrap so we don't mix core dependencies
+                  isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
+                  isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("test.apt.bingner.com") == false,
+                  isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.elucubratus.com") == false,
+                  !isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.procurs.us") == false
             else {
                 continue
             }
@@ -198,7 +203,11 @@ final class RepoManager {
         }
         
         guard !hasRepo(with: normalizedURL),
-              normalizedURL.host?.localizedCaseInsensitiveContains("repo.chariz.io") == false
+              // Prevent cross adding when using a certain bootstrap so we don't mix core dependencies
+              isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.bingner.com") == false,
+              isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("test.apt.bingner.com") == false,
+              isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.elucubratus.com") == false,
+              !isProcursus && normalizedURL.host?.localizedCaseInsensitiveContains("apt.procurs.us") == false
         else {
             return nil
         }

--- a/Sileo/Backend/Root Wrapper/RootWrapper.swift
+++ b/Sileo/Backend/Root Wrapper/RootWrapper.swift
@@ -280,12 +280,72 @@ func moveFileAsRoot(from: URL, to: URL) {
 }
 
 public class CommandPath {
+    // Certain paths need to check for either Procursus mobile or Elucubratus as a fallback option
+    // Every method that uses this check already accounts for macCatalyst paths still resolving too
+    private static var isProcursus = FileManager.default.fileExists(atPath: "/etc/apt/trusted.gpg.d/memo.gpg")
+    
     // swiftlint:disable identifier_name
     static var mv: String = {
-        #if targetEnvironment(macCatalyst)
+        if isProcursus {
+            return "/usr/bin/mv"
+        }
+
         return "/bin/mv"
+    }()
+    
+    static var chmod: String = {
+        if isProcursus {
+            return "/usr/bin/chmod"
+        }
+
+        return "/bin/chmod"
+    }()
+
+    // swiftlint:disable identifier_name
+    static var ln: String = {
+        if isProcursus {
+            return "/usr/bin/ln"
+        }
+ 
+        return "/bin/ln"
+    }()
+
+    // swiftlint:disable identifier_name
+    static var rm: String = {
+        if isProcursus {
+            return "/usr/bin/rm"
+        }
+
+        return "/bin/rm"
+    }()
+    
+    static var mkdir: String = {
+        if isProcursus {
+            return "/usr/bin/mkdir"
+        }
+        
+        return "/bin/mkdir"
+    }()
+
+    // swiftlint:disable identifier_name
+    static var cp: String = {
+        if isProcursus {
+            return "/usr/bin/cp"
+        }
+        
+        return "/bin/cp"
+    }()
+    
+    static var sourcesListD: String = {
+        // Check for not Procursus so we can keep the check below
+        if !isProcursus {
+            return "/etc/apt/sileo.list.d"
+        }
+        
+        #if targetEnvironment(macCatalyst)
+        return "/opt/procursus/etc/apt/sources.list.d"
         #else
-        return "/usr/bin/mv"
+        return "/etc/apt/sources.list.d"
         #endif
     }()
     
@@ -294,46 +354,6 @@ public class CommandPath {
         return "/usr/sbin/chown"
         #else
         return "/usr/bin/chown"
-        #endif
-    }()
-    
-    static var chmod: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/bin/chmod"
-        #else
-        return "/usr/bin/chmod"
-        #endif
-    }()
-    // swiftlint:disable identifier_name
-    static var ln: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/bin/ln"
-        #else
-        return "/usr/bin/ln"
-        #endif
-    }()
-    // swiftlint:disable identifier_name
-    static var rm: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/bin/rm"
-        #else
-        return "/usr/bin/rm"
-        #endif
-    }()
-    
-    static var mkdir: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/bin/mkdir"
-        #else
-        return "/usr/bin/mkdir"
-        #endif
-    }()
-    // swiftlint:disable identifier_name
-    static var cp: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/bin/cp"
-        #else
-        return "/usr/bin/cp"
         #endif
     }()
     
@@ -376,6 +396,7 @@ public class CommandPath {
         return "/usr/bin/apt-key"
         #endif
     }()
+
     // swiftlint:disable identifier_name
     static var sh: String = {
         "/bin/sh"
@@ -412,14 +433,6 @@ public class CommandPath {
         return Bundle.main.bundleURL
         #else
         return URL(fileURLWithPath: "/Library/dpkg")
-        #endif
-    }()
-    
-    static var sourcesListD: String = {
-        #if targetEnvironment(macCatalyst)
-        return "/opt/procursus/etc/apt/sources.list.d"
-        #else
-        return "/etc/apt/sources.list.d"
         #endif
     }()
     

--- a/layout/DEBIAN/postinst.elu.in
+++ b/layout/DEBIAN/postinst.elu.in
@@ -27,6 +27,41 @@ case "$1" in
 			echo "" > $sourcesDir/sileo.sources
 		fi
 
+		if [ -s $sourcesDir/cydia.list ]; then
+			if grep -Fxq "deb https://apt.bingner.com/ ./" $sourcesDir/cydia.list; then
+				rm -rf /etc/apt/sources.list.d/sileo.sources
+				sourcesDir="/etc/apt/sileo.list.d"
+
+				if ! [ -s $sourcesDir ]; then
+					mkdir -p $sourcesDir
+					touch $sourcesDir/sileo.sources
+
+				fi
+
+				if ! grep -Fxq "URIs: http://apt.thebigboss.org/repofiles/cydia/" $sourcesDir/sileo.sources ;
+					then
+						echo "Installed BigBoss Repo"
+						sed -i '1s;^;Types: deb\
+URIs: http://apt.thebigboss.org/repofiles/cydia/\
+Suites: stable\
+Components: main\
+\
+;' $sourcesDir/sileo.sources
+				fi
+
+				if ! [ -s $sourcesDir/elucubratus.sources ]; then
+					echo "Installed Elucubratus Repo"
+					echo "" > $sourcesDir/elucubratus.sources
+					sed -i '1s;^;Types: deb\
+URIs: https://apt.bingner.com/\
+Suites: ./\
+Components:\
+\
+;' $sourcesDir/elucubratus.sources
+				fi
+			fi
+		fi
+
 		if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;
 		then
 			echo "Installed Chariz Repo"
@@ -48,10 +83,14 @@ Components:\
 \
 ;' $sourcesDir/sileo.sources
 		fi
-		rm -rf $sourcesDir/../preferences.d/checkra1n
 		exit 0
 		;;
 	(triggered)
+		if [ "$2" == "/Library/MobileSubstrate/DynamicLibraries" ]; then
+			finish restart
+			exit 0
+		fi
+
 		finish uicache
 		exit 0
 		;;

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -86,6 +86,11 @@ Components:\
 		exit 0
 		;;
 	(triggered)
+		if [ "$2" == "/Library/MobileSubstrate/DynamicLibraries" ]; then
+			finish restart
+			exit 0
+		fi
+
 		finish uicache
 		exit 0
 		;;

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -38,6 +38,17 @@ case "$1" in
 
 				fi
 
+				if ! grep -Fxq "URIs: http://apt.thebigboss.org/repofiles/cydia/" $sourcesDir/sileo.sources ;
+					then
+						echo "Installed BigBoss Repo"
+						sed -i '1s;^;Types: deb\
+URIs: http://apt.thebigboss.org/repofiles/cydia/\
+Suites: stable\
+Components: main\
+\
+;' $sourcesDir/sileo.sources
+				fi
+
 				if ! [ -s $sourcesDir/elucubratus.sources ]; then
 					echo "Installed Elucubratus Repo"
 					echo "" > $sourcesDir/elucubratus.sources
@@ -49,17 +60,6 @@ Components:\
 ;' $sourcesDir/elucubratus.sources
 				fi
 			fi
-		fi
-
-		if ! grep -Fxq "URIs: http://apt.thebigboss.org/repofiles/cydia/" $sourcesDir/sileo.sources ;
-		then
-			echo "Installed BigBoss Repo"
-			sed -i '1s;^;Types: deb\
-URIs: http://apt.thebigboss.org/repofiles/cydia/\
-Suites: stable\
-Components: main\
-\
-;' $sourcesDir/sileo.sources
 		fi
 
 		if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;

--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -7,8 +7,8 @@ finish() {
 	# No control fd: bail out
 	[ -z "${f}" ] || [ -z "${SILEO}" ] && return
 
-	read -r fd ver <<-EOF                    
-			${SILEO}                                    
+	read -r fd ver <<-EOF
+			${SILEO}
 			EOF
 
 	# Sileo control fd version < 1: bail out
@@ -25,6 +25,41 @@ case "$1" in
 
 		if ! [ -s "$sourcesDir/sileo.sources" ]; then
 			echo "" > $sourcesDir/sileo.sources
+		fi
+
+		if [ -s $sourcesDir/cydia.list ]; then
+			if grep -Fxq "deb https://apt.bingner.com/ ./" $sourcesDir/cydia.list; then
+				rm -rf /etc/apt/sources.list.d/sileo.sources
+				sourcesDir="/etc/apt/sileo.list.d"
+
+				if ! [ -s $sourcesDir ]; then
+					mkdir -p $sourcesDir
+					touch $sourcesDir/sileo.sources
+
+				fi
+
+				if ! [ -s $sourcesDir/elucubratus.sources ]; then
+					echo "Installed Elucubratus Repo"
+					echo "" > $sourcesDir/elucubratus.sources
+					sed -i '1s;^;Types: deb\
+URIs: https://apt.bingner.com/\
+Suites: ./\
+Components:\
+\
+;' $sourcesDir/elucubratus.sources
+				fi
+			fi
+		fi
+
+		if ! grep -Fxq "URIs: http://apt.thebigboss.org/repofiles/cydia/" $sourcesDir/sileo.sources ;
+		then
+			echo "Installed BigBoss Repo"
+			sed -i '1s;^;Types: deb\
+URIs: http://apt.thebigboss.org/repofiles/cydia/\
+Suites: stable\
+Components: main\
+\
+;' $sourcesDir/sileo.sources
 		fi
 
 		if ! grep -Fxq "URIs: https://repo.chariz.com/" $sourcesDir/sileo.sources ;
@@ -48,7 +83,6 @@ Components:\
 \
 ;' $sourcesDir/sileo.sources
 		fi
-		rm -rf $sourcesDir/../preferences.d/checkra1n
 		exit 0
 		;;
 	(triggered)

--- a/layout/DEBIAN/triggers
+++ b/layout/DEBIAN/triggers
@@ -1,2 +1,2 @@
 interest /Applications
-
+interest /Library/MobileSubstrate/DynamicLibraries

--- a/layout/DEBIAN/triggers
+++ b/layout/DEBIAN/triggers
@@ -1,2 +1,2 @@
 interest /Applications
-interest /Library/MobileSubstrate/DynamicLibraries
+

--- a/layout/DEBIAN/triggers.elu
+++ b/layout/DEBIAN/triggers.elu
@@ -1,0 +1,2 @@
+interest /Applications
+interest /Library/MobileSubstrate/DynamicLibraries


### PR DESCRIPTION
Now that #161 has finally been completed and merged into the `dev` branch, we can finally look at implementing the remaining bits for official Elucubratus support into the upstream.

- [x] Adding support for automatic path detection for Elucubratus/Procursus
- [x] Changing the Makefile to support our older dependencies
- [x] Unbanning Bingner/Elucubratus from being added via RepoManager
- [x] Adding BigBoss by default (only on Elucubratus) because it hosts core dependencies like `preferenceloader` still 😐
- [x] Supporting `libzstd` by using my compiled version for CFVersion 1400 and fixing any TBD issues

If there are any changes to implementation that you believe are the better course of action please let me know. However, as of now, I think I'm approaching this in the best possible manner by detecting the Procursus `memo.gpg`.