### PR TITLE
fix for installing on Taurine 1.1.2

### DIFF
--- a/layout/DEBIAN/postinst.in
+++ b/layout/DEBIAN/postinst.in
@@ -75,4 +75,8 @@ Components:\
 		;;
 esac
 
+if [ -z "${SILEO}" ]; then echo "Not running in Sileo. Trigger UICache"; fi
+if [ -z "${SILEO}" ]; then uicache -p /Applications/@@SILEO_APP@@; fi
+
+
 exit 0


### PR DESCRIPTION
hayden's commit broke installing Sileo w/Taurine 1.1.2, this adds it back