### PR TITLE
Add support for importing repos from a .sources file

### DIFF
--- a/Sileo Demo/Info.plist
+++ b/Sileo Demo/Info.plist
@@ -172,6 +172,29 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>$(PRODUCT_NAME) Sources File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.sileo.sources</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sources</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-sources-file</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -1179,8 +1179,9 @@ final class RepoManager {
         }
     }
 
-    private func parseSourcesFile(at url: URL) {
+    public func parseSourcesFile(at url: URL) {
         guard let rawSources = try? String(contentsOf: url) else {
+            print("\(#function): couldn't get rawSources. we are out of here!")
             return
         }
         let repoEntries = rawSources.components(separatedBy: "\n\n")
@@ -1192,6 +1193,7 @@ final class RepoManager {
                   let rawSuites = repoData["suites"],
                   let rawComponents = repoData["components"]
             else {
+                print("\(#function): Couldn't parse repo data for Entry \(repoEntry)")
                 continue
             }
 

--- a/Sileo/Info.plist
+++ b/Sileo/Info.plist
@@ -486,6 +486,29 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>$(PRODUCT_NAME) Sources File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.sileo.sources</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sources</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-sources-file</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -189,7 +189,7 @@ final class SourcesViewController: SileoViewController {
             
             let _tmpManager = RepoManager()
             _tmpManager.parseSourcesFile(at: firstURL)
-            let URLs = _tmpManager.repoList.compactMap { $0.url }
+            let URLs = _tmpManager.repoList.compactMap(\.url)
             sourcesVC?.handleSourceAdd(urls: URLs, bypassFlagCheck: false)
             sourcesVC?.refreshSources(forceUpdate: true, forceReload: true)
         }

--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -147,13 +147,54 @@ final class SourcesViewController: SileoViewController {
                 nav.rightBarButtonItem = UIBarButtonItem(title: exportTitle, style: .plain, target: self, action: #selector(self.exportSources(_:)))
             } else {
                 nav.leftBarButtonItem = UIBarButtonItem(title: String(localizationKey: "Edit"), style: .done, target: self, action: #selector(self.toggleEditing(_:)))
-                nav.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(self.addSource(_:)))
+                if #available(iOS 14.0, *) {
+                    let promptAddRepoAction = UIAction(title: "Add Repo", image: .init(systemName: "plus.circle")) { _ in
+                        self.addSource(nil)
+                    }
+                    
+                    let importReposAction = UIAction(title: "Import Repos", image: .init(systemName: "archivebox")) { _ in
+                        self.importRepos()
+                    }
+                    
+                    let menu = UIMenu(title: "Add Repos", children: [promptAddRepoAction, importReposAction])
+                    nav.rightBarButtonItem = UIBarButtonItem(systemItem: .add, primaryAction: promptAddRepoAction, menu: menu)
+                } else {
+                    nav.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(self.addSource(_:)))
+                }
             }
             
         }
     }
     #endif
     
+    @available(iOS 14.0, *)
+    private func importRepos() {
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        let delegate = SourcesPickerImporterDelegate.shared
+        delegate.sourcesVC = self
+        controller.delegate = delegate
+        self.present(controller, animated: true, completion: nil)
+    }
+    
+    class SourcesPickerImporterDelegate: NSObject, UIDocumentPickerDelegate {
+        var sourcesVC: SourcesViewController? = nil
+        
+        static var shared = SourcesPickerImporterDelegate()
+        
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let firstURL = urls.first else {
+                print("Couldn't pick a file? shame on you")
+                return
+            }
+            
+            let _tmpManager = RepoManager()
+            _tmpManager.parseSourcesFile(at: firstURL)
+            let URLs = _tmpManager.repoList.compactMap { $0.url }
+            sourcesVC?.handleSourceAdd(urls: URLs, bypassFlagCheck: false)
+            sourcesVC?.refreshSources(forceUpdate: true, forceReload: true)
+        }
+    }
+     
     @objc private func handleImageUpdate(_ notification: Notification) {
         if !Thread.isMainThread {
             DispatchQueue.main.async {


### PR DESCRIPTION
This Pull Request adds the ability to import several Repositories from a .sources file in Sileo on iOS 14+.

The default action when short pressing the "+" button in the Sources View Controller is still the normal 'Add Source' alert with the TextField for the repo URL, however, when long pressing the "+" button, the user is prompted with the iOS file picker (UIDocumentPickerViewController) to select a file, Sileo parse that file then adds the repos from that file. See the video below

https://user-images.githubusercontent.com/48022799/164115116-52443295-a7cc-4566-b96f-a60ce6bd1de1.mov

