### PR TITLE
Add support for importing files from .list and Plaintext files, support for importing .sources and .list files when exported from other apps

### DIFF
--- a/Sileo Demo/Info.plist
+++ b/Sileo Demo/Info.plist
@@ -176,6 +176,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.content</string>
+				<string>public.data</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>$(PRODUCT_NAME) Sources File</string>
@@ -192,6 +193,25 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>application/x-sources-file</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeDescription</key>
+			<string>$(PRODUCT_NAME) List File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.sileo.list</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>list</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-list-file</string>
 				</array>
 			</dict>
 		</dict>

--- a/Sileo Demo/Info.plist
+++ b/Sileo Demo/Info.plist
@@ -27,6 +27,26 @@
 				<string>org.debian.deb-archive</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>$(PRODUCT_NAME) Sources File</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.sileo.sources</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>$(PRODUCT_NAME) List File</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.sileo.list</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
@@ -197,6 +217,11 @@
 			</dict>
 		</dict>
 		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.content</string>
+				<string>public.data</string>
+			</array>
 			<key>UTTypeDescription</key>
 			<string>$(PRODUCT_NAME) List File</string>
 			<key>UTTypeIconFiles</key>

--- a/Sileo/Backend/Repo Manager/RepoManager.swift
+++ b/Sileo/Backend/Repo Manager/RepoManager.swift
@@ -1157,9 +1157,13 @@ final class RepoManager {
         }
     }
     
-    private func parseListFile(at url: URL) {
-        if CommandPath.isMobileProcursus {
-            guard url.lastPathComponent != "cydia.list" else { return }
+    public func parseListFile(at url: URL, isImporting: Bool = false) {
+        // if we're importing, then it doesn't matter if the file is a cydia.list
+        // otherwise, don't parse the file
+        if CommandPath.isMobileProcursus, !isImporting {
+            guard url.lastPathComponent != "cydia.list" else {
+                return
+            }
         }
         guard let rawList = try? String(contentsOf: url) else { return }
 
@@ -1179,6 +1183,17 @@ final class RepoManager {
         }
     }
 
+    public func parsePlainTextFile(at url: URL) {
+        guard let rawSources = try? String(contentsOf: url) else {
+            print("couldn't get rawSources. we are out of here!")
+            return
+        }
+        let urlsString = rawSources.components(separatedBy: "\n").filter { URL(string: $0) != nil }
+        print("urls to add: \(urlsString)")
+        
+        parseRepoEntry(rawSources, at: url, withTypes: ["deb"], uris: urlsString, suites: ["./"], components: [])
+    }
+    
     public func parseSourcesFile(at url: URL) {
         guard let rawSources = try? String(contentsOf: url) else {
             print("\(#function): couldn't get rawSources. we are out of here!")

--- a/Sileo/Info.plist
+++ b/Sileo/Info.plist
@@ -490,6 +490,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.content</string>
+				<string>public.data</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>$(PRODUCT_NAME) Sources File</string>
@@ -506,6 +507,30 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>application/x-sources-file</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.content</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>$(PRODUCT_NAME) List File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.sileo.list</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>list</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/x-list-file</string>
 				</array>
 			</dict>
 		</dict>

--- a/Sileo/Info.plist
+++ b/Sileo/Info.plist
@@ -27,6 +27,26 @@
 				<string>org.debian.deb-archive</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>$(PRODUCT_NAME) Sources File</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.sileo.sources</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>$(PRODUCT_NAME) List File</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.sileo.list</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -153,7 +153,7 @@ final class SourcesViewController: SileoViewController {
                     }
                     
                     let importReposAction = UIAction(title: "Import Repos", image: .init(systemName: "archivebox")) { _ in
-                        self.importRepos()
+                        self.promptImportRepos()
                     }
                     
                     let menu = UIMenu(title: "Add Repos", children: [promptAddRepoAction, importReposAction])
@@ -166,6 +166,26 @@ final class SourcesViewController: SileoViewController {
         }
     }
     #endif
+    
+    func importRepos(fromURL url: URL) {
+        let _tmpManager = RepoManager()
+        
+        print("Will now import URL \(url)")
+        if url.pathExtension == "list" {
+            print("detected list file.")
+            _tmpManager.parseListFile(at: url, isImporting: true)
+        } else if url.pathExtension == "sources" {
+            print("detected sources file")
+            _tmpManager.parseSourcesFile(at: url)
+        } else {
+            print("detected plaintext file")
+            _tmpManager.parsePlainTextFile(at: url)
+        }
+        
+        let URLs = _tmpManager.repoList.compactMap(\.url)
+        self.handleSourceAdd(urls: URLs, bypassFlagCheck: false)
+        self.refreshSources(forceUpdate: true, forceReload: true)
+    }
     
     @available(iOS 14.0, *)
     private func importRepos() {
@@ -187,23 +207,7 @@ final class SourcesViewController: SileoViewController {
                 return
             }
             
-            let _tmpManager = RepoManager()
-            
-            if firstURL.pathExtension == "list" {
-                print("detected list file.")
-                _tmpManager.parseListFile(at: firstURL, isImporting: true)
-            } else if firstURL.pathExtension == "sources" {
-                print("detected sources file")
-                _tmpManager.parseSourcesFile(at: firstURL)
-            } else {
-                // support for URLs in plaintext files
-                print("detected plaintext file")
-                _tmpManager.parsePlainTextFile(at: firstURL)
-            }
-            
-            let URLs = _tmpManager.repoList.compactMap(\.url)
-            sourcesVC?.handleSourceAdd(urls: URLs, bypassFlagCheck: false)
-            sourcesVC?.refreshSources(forceUpdate: true, forceReload: true)
+            sourcesVC?.importRepos(fromURL: firstURL)
         }
     }
      

--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -188,7 +188,7 @@ final class SourcesViewController: SileoViewController {
     }
     
     @available(iOS 14.0, *)
-    private func importRepos() {
+    private func promptImportRepos() {
         let controller = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
         let delegate = SourcesPickerImporterDelegate.shared
         delegate.sourcesVC = self

--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -188,7 +188,19 @@ final class SourcesViewController: SileoViewController {
             }
             
             let _tmpManager = RepoManager()
-            _tmpManager.parseSourcesFile(at: firstURL)
+            
+            if firstURL.pathExtension == "list" {
+                print("detected list file.")
+                _tmpManager.parseListFile(at: firstURL, isImporting: true)
+            } else if firstURL.pathExtension == "sources" {
+                print("detected sources file")
+                _tmpManager.parseSourcesFile(at: firstURL)
+            } else {
+                // support for URLs in plaintext files
+                print("detected plaintext file")
+                _tmpManager.parsePlainTextFile(at: firstURL)
+            }
+            
             let URLs = _tmpManager.repoList.compactMap(\.url)
             sourcesVC?.handleSourceAdd(urls: URLs, bypassFlagCheck: false)
             sourcesVC?.refreshSources(forceUpdate: true, forceReload: true)


### PR DESCRIPTION
For plaintext files, the format of the repos is the repo URL separated by a newline

An example of a plaintext file that could be imported into Sileo with this PR:
```
https://havoc.app/
https://apt.arx8x.net/
https://creaturecoding.com/repo/
https://cydia.akemi.ai/
```

Edit: this PR also now adds the ability to import .sources and .list files when exported from other applications, such as in the iOS share sheet:
![image](https://user-images.githubusercontent.com/48022799/166111330-9f63fa78-039e-4cda-95c0-ee11a64b75b4.png)



