### PR TITLE
Organise makefile

### DIFF
--- a/giveMeRoot/Makefile
+++ b/giveMeRoot/Makefile
@@ -1,5 +1,5 @@
 TARGET  = giveMeRoot
-OUTDIR ?= bin
+OUTDIR ?= bin/
 CC             ?= xcrun -sdk iphoneos clang -arch arm64 -mios-version-min=12.0
 
 TAGET_CODESIGN ?= ldid


### PR DESCRIPTION
Make the Makefile friendlier to navigate;
Fix a minor bug caused by variable being passed to wrong process;
Implemented ".DEFAULT_GOAL" to point to package (ie command "make" = "make package").

This is a duplicate of pr #230, since that one was aimed at the wrong branch and was overridden with conflicts. I talked about some of the above changes there.
