### PR TITLE
Change repo swipe action to use icons

### DIFF
--- a/Sileo/UI/SourcesViewController/SourcesViewController.swift
+++ b/Sileo/UI/SourcesViewController/SourcesViewController.swift
@@ -857,6 +857,10 @@ extension SourcesViewController: UITableViewDelegate { // UITableViewDelegate
             self?.deleteRepo(at: indexPath)
             completionHandler(true)
         }
+        
+        // on iOS 12, the icons won't display and instead the text will be displayed
+        refresh.image = .init(systemNameOrNil: "arrow.clockwise")
+        remove.image = .init(systemNameOrNil: "trash")
         return UISwipeActionsConfiguration(actions: [remove, refresh])
     }
 }


### PR DESCRIPTION
This pull request changes the appearance of swipe actions when swiping on a repo.

Before:
![before](https://cdn.discordapp.com/attachments/779844089196576809/972567096494010488/IMG_1889.png)

After (with this pull request):
![after](https://cdn.discordapp.com/attachments/863878431166169100/972583777983397978/DBDDC072-FAE2-4381-99A4-DFA8EB6D888C.jpg)