### PR TITLE
Make package name red if firmware conflict

### DIFF
--- a/Sileo/Backend/Objects/Package.swift
+++ b/Sileo/Backend/Objects/Package.swift
@@ -32,6 +32,9 @@ final class Package: Hashable, Equatable {
     public var installedSize: Int?
     public var tags: PackageTags = .none
     public var nativeDepiction: String?
+    public var depends: String?
+    public var conflicts: String?
+    public var isFirmwareConflict: Bool?
     
     public var allVersionsInternal = [String: Package]()
     public var allVersions: [Package] {

--- a/Sileo/Backend/Objects/Package.swift
+++ b/Sileo/Backend/Objects/Package.swift
@@ -34,6 +34,8 @@ final class Package: Hashable, Equatable {
     public var nativeDepiction: String?
     public var depends: String?
     public var conflicts: String?
+    public var preDepends: String?
+    public var breaks: String?
     public var isFirmwareConflict: Bool?
     
     public var allVersionsInternal = [String: Package]()

--- a/Sileo/Backend/Objects/Package.swift
+++ b/Sileo/Backend/Objects/Package.swift
@@ -34,8 +34,6 @@ final class Package: Hashable, Equatable {
     public var nativeDepiction: String?
     public var depends: String?
     public var conflicts: String?
-    public var preDepends: String?
-    public var breaks: String?
     public var isFirmwareConflict: Bool?
     
     public var allVersionsInternal = [String: Package]()

--- a/Sileo/Backend/Package Manager/PackageListManager.swift
+++ b/Sileo/Backend/Package Manager/PackageListManager.swift
@@ -181,6 +181,8 @@ final class PackageListManager {
         
         package.depends = dictionary["depends"]
         package.conflicts = dictionary["conflicts"]
+        package.preDepends = dictionary["pre-depends"]
+        package.breaks = dictionary["breaks"]
         
         if let installedSize = dictionary["installed-size"] {
             package.installedSize = Int(installedSize)
@@ -560,4 +562,3 @@ final class PackageListManager {
         }
     }
 }
-

--- a/Sileo/Backend/Package Manager/PackageListManager.swift
+++ b/Sileo/Backend/Package Manager/PackageListManager.swift
@@ -363,7 +363,7 @@ final class PackageListManager {
             packageList.removeAll { package in
                 // check if the user search term is in the package ID, description or in the author / maintainer name
                 for field in [package.package, package.package, package.author, package.maintainer] {
-                    if field?.localizedStandardContains(search!) ?? false { return false }
+                    if field?.localizedStandardContains(search) ?? false { return false }
                 }
                 
                 return true

--- a/Sileo/Backend/Package Manager/PackageListManager.swift
+++ b/Sileo/Backend/Package Manager/PackageListManager.swift
@@ -181,8 +181,6 @@ final class PackageListManager {
         
         package.depends = dictionary["depends"]
         package.conflicts = dictionary["conflicts"]
-        package.preDepends = dictionary["pre-depends"]
-        package.breaks = dictionary["breaks"]
         
         if let installedSize = dictionary["installed-size"] {
             package.installedSize = Int(installedSize)

--- a/Sileo/Backend/Package Manager/PackageListManager.swift
+++ b/Sileo/Backend/Package Manager/PackageListManager.swift
@@ -179,6 +179,9 @@ final class PackageListManager {
         package.depiction = dictionary["sileodepiction"]
         package.nativeDepiction = dictionary["native-depiction"]
         
+        package.depends = dictionary["depends"]
+        package.conflicts = dictionary["conflicts"]
+        
         if let installedSize = dictionary["installed-size"] {
             package.installedSize = Int(installedSize)
         }
@@ -358,7 +361,7 @@ final class PackageListManager {
             packageList.removeAll { package in
                 // check if the user search term is in the package ID, description or in the author / maintainer name
                 for field in [package.package, package.package, package.author, package.maintainer] {
-                    if field?.localizedStandardContains(search) ?? false { return false }
+                    if field?.localizedStandardContains(search!) ?? false { return false }
                 }
                 
                 return true
@@ -557,3 +560,4 @@ final class PackageListManager {
         }
     }
 }
+

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -596,7 +596,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
                 noSpaceIter += 1
                 continue
             }
-            let baseString = String(noSpace[startIndex..<endIndex]).replacingOccurrences(of: ")", with: "") //we shouldn't need to remove (, only )
+            let baseString = String(noSpace[startIndex..<endIndex])
             if baseString.contains("|") {
                 //something other than firmware
                 noSpaceIter += 1
@@ -613,7 +613,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             var versionParsed = Float(-1)
             for i in baseString {
                 if i.isWholeNumber {
-                    versionParsed = Float(baseString.dropFirst(iterator)) ?? Float(-1)
+                    versionParsed = Float(baseString.dropFirst(iterator).replacingOccurrences(of: ")", with: "") /*we shouldn't need to remove (, only )*/) ?? Float(-1)
                     break; //we found the char
                 } else if i == ">" {
                     operatorType = 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwipeCellKit
 import Evander
+import UIKit
 
 class PackageCollectionViewCell: SwipeCollectionViewCell {
     @IBOutlet var imageView: UIImageView?
@@ -43,34 +44,129 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         
                 titleLabel?.textColor = targetPackage.commercial ? self.tintColor : .sileoLabel
                 
-                //#if os(iOS)
-
-                let deponfw = (targetPackage.depends ?? "Depends: firmware (>= 0.0)") + ","
-
+                #if os(iOS)
+                
+                let deponfw = "Depends: " + (targetPackage.depends ?? "boobs") + ","
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = (targetPackage.conflicts ?? "Conflicts: firmware (>= 9999999.0)") + ","
+                        let conflictwithfw = (targetPackage.conflicts ?? "cock") + ","
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
+                            } else {
+                                let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                                if preDepends.contains("firmware") {
+                                    if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                        titleLabel?.textColor = UIColor.red
+                                        targetPackage.isFirmwareConflict = true
+                                    } else {
+                                        let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                        if breaks.contains("firmware") {
+                                            if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                                titleLabel?.textColor = UIColor.red
+                                                targetPackage.isFirmwareConflict = true
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                    if breaks.contains("firmware") {
+                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                            titleLabel?.textColor = UIColor.red
+                                            targetPackage.isFirmwareConflict = true
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                            if preDepends.contains("firmware") {
+                                if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                    titleLabel?.textColor = UIColor.red
+                                    targetPackage.isFirmwareConflict = true
+                                } else {
+                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                    if breaks.contains("firmware") {
+                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                            titleLabel?.textColor = UIColor.red
+                                            targetPackage.isFirmwareConflict = true
+                                        }
+                                    }
+                                }
+                            } else {
+                                let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                if breaks.contains("firmware") {
+                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                        titleLabel?.textColor = UIColor.red
+                                        targetPackage.isFirmwareConflict = true
+                                    }
+                                }
                             }
                         }
                     }
                 } else {
-                    let conflictwithfw = (targetPackage.conflicts ?? "Conflicts: firmware (>= 9999999.0)") + ","
+                    let conflictwithfw = "Conflicts: " + (targetPackage.conflicts ?? "cock") + ","
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
                             targetPackage.isFirmwareConflict = true
+                        } else {
+                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                            if preDepends.contains("firmware") {
+                                if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                    titleLabel?.textColor = UIColor.red
+                                    targetPackage.isFirmwareConflict = true
+                                } else {
+                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                    if breaks.contains("firmware") {
+                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                            titleLabel?.textColor = UIColor.red
+                                            targetPackage.isFirmwareConflict = true
+                                        }
+                                    }
+                                }
+                            } else {
+                                let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                if breaks.contains("firmware") {
+                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                        titleLabel?.textColor = UIColor.red
+                                        targetPackage.isFirmwareConflict = true
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                        if preDepends.contains("firmware") {
+                            if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                titleLabel?.textColor = UIColor.red
+                                targetPackage.isFirmwareConflict = true
+                            } else {
+                                let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                if breaks.contains("firmware") {
+                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                        titleLabel?.textColor = UIColor.red
+                                        targetPackage.isFirmwareConflict = true
+                                    }
+                                }
+                            }
+                        } else {
+                            let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                            if breaks.contains("firmware") {
+                                if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                    titleLabel?.textColor = UIColor.red
+                                    targetPackage.isFirmwareConflict = true
+                                }
+                            }
                         }
                     }
                 }
 
-                //#endif
+                #endif
             }
             unreadView?.isHidden = true
             
@@ -502,7 +598,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             }
             let baseString = String(noSpace[startIndex..<endIndex]).replacingOccurrences(of: ")", with: "") //we shouldn't need to remove (, only )
             if baseString.contains("|") {
-                print("something other than firmware")
+                //something other than firmware
                 noSpaceIter += 1
                 continue //we don't actually want to mark as red if something other than the firmware conflicts, so firmware (>= 13.0) | somedeb gets marked as false even if firmware is lower than 13.0, since somedeb isn't firmware
             }
@@ -530,9 +626,6 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             }
             if versionParsed == -1 {
                 print("COULD NOT FIND VERSIONPARSED")
-                print(confOrDependString)
-                print(baseString)
-                print(noSpaceIter)
                 noSpaceIter += 1
                 continue
             }

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,13 +46,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = targetPackage.depends ?? "abcd"
+                let deponfw = "," + (targetPackage.depends ?? "abcd")
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = targetPackage.conflicts ?? "abcd"
+                        let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
@@ -61,7 +61,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         }
                     }
                 } else {
-                    let conflictwithfw = targetPackage.conflicts ?? "abcd"
+                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
@@ -484,12 +484,12 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
     private func doesNotDepend(confOrDependString: String, forVersion ver: Float) -> Bool {
         let noSpaceFull = confOrDependString.replacingOccurrences(of: " ", with: "");
         var noSpaceIter = 0
-        for noSpace in noSpaceFull.components(separatedBy: "firmware(")  { //support for two firmware depends in one field
+        for noSpace in noSpaceFull.components(separatedBy: ",firmware(")  { //support for two firmware depends in one field
             if noSpaceIter == 0 {
                 noSpaceIter += 1
                 continue;
             }
-            let endIndex = (noSpace.range(of: ",", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound) ?? noSpace.endIndex
+            let endIndex = (noSpace.range(of: "),", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound) ?? noSpace.endIndex
             let baseString = String(noSpace[..<endIndex])
             if baseString.count < 1 {
                 noSpaceIter += 1
@@ -511,7 +511,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             var versionParsed = Float(-1)
             for i in baseString {
                 if i.isWholeNumber {
-                    versionParsed = Float(baseString.dropFirst(iterator).replacingOccurrences(of: ")", with: "") /*we shouldn't need to remove (, only )*/) ?? Float(-1)
+                    versionParsed = Float(baseString.dropFirst(iterator) ?? Float(-1)
                     break; //we found the char
                 } else if i == ">" {
                     operatorType = 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -45,10 +45,12 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
+                DispatchQueue.main.async {
+                let ver = (UIDevice.current.systemVersion as NSString).floatValue
                 DispatchQueue.global(qos: .userInitiated).async {
                 let deponfw = "," + (targetPackage.depends ?? "abcd")
                 if deponfw.contains("firmware") {
-                    if self.doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                    if self.doesNotDepend(confOrDependString: deponfw, forVersion: ver) {
                         targetPackage.isFirmwareConflict = true
                         DispatchQueue.main.async {
                             self.titleLabel?.textColor = UIColor.red
@@ -56,7 +58,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                     } else {
                         let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                         if conflictwithfw.contains("firmware") {
-                            if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                            if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: ver) {
                                 targetPackage.isFirmwareConflict = true
                                 DispatchQueue.main.async {
                                     self.titleLabel?.textColor = UIColor.red
@@ -67,13 +69,14 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 } else {
                     let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                     if conflictwithfw.contains("firmware") {
-                        if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                        if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: ver) {
                             targetPackage.isFirmwareConflict = true
                             DispatchQueue.main.async {
                                 self.titleLabel?.textColor = UIColor.red
                             }
                         }
                     }
+                }
                 }
                 }
 
@@ -496,7 +499,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
                 noSpaceIter += 1
                 continue;
             }
-            let endIndex = (noSpace.range(of: "),", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound) ?? noSpace.endIndex
+            let endIndex = (noSpace.range(of: ",")?.lowerBound) ?? noSpace.endIndex
             let baseString = String(noSpace[..<endIndex])
             if baseString.contains("|") {
                 //something other than firmware
@@ -513,7 +516,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             var versionParsed = Float(-1)
             for i in baseString {
                 if i.isWholeNumber {
-                    versionParsed = Float(baseString.dropFirst(iterator)) ?? Float(-1)
+                    versionParsed = Float(baseString.dropFirst(iterator).replacingOccurrences(of: ")", with: "")) ?? Float(-1)
                     break; //we found the char
                 } else if i == ">" {
                     operatorType = 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -5,7 +5,6 @@
 //  Created by CoolStar on 7/30/19.
 //  Copyright © 2022 Sileo Team. All rights reserved.
 //
-
 import Foundation
 import SwipeCellKit
 import Evander
@@ -46,28 +45,36 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
+                DispatchQueue.global(qos: .userInitiated).async {
                 let deponfw = "," + (targetPackage.depends ?? "abcd")
                 if deponfw.contains("firmware") {
-                    if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
-                        titleLabel?.textColor = UIColor.red
+                    if self.doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         targetPackage.isFirmwareConflict = true
+                        DispatchQueue.main.async {
+                            self.titleLabel?.textColor = UIColor.red
+                        }
                     } else {
                         let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                         if conflictwithfw.contains("firmware") {
-                            if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                titleLabel?.textColor = UIColor.red
+                            if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 targetPackage.isFirmwareConflict = true
+                                DispatchQueue.main.async {
+                                    self.titleLabel?.textColor = UIColor.red
+                                }
                             }
                         }
                     }
                 } else {
                     let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                     if conflictwithfw.contains("firmware") {
-                        if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
-                            titleLabel?.textColor = UIColor.red
+                        if !self.doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             targetPackage.isFirmwareConflict = true
+                            DispatchQueue.main.async {
+                                self.titleLabel?.textColor = UIColor.red
+                            }
                         }
                     }
+                }
                 }
 
                 #endif
@@ -506,7 +513,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             var versionParsed = Float(-1)
             for i in baseString {
                 if i.isWholeNumber {
-                    versionParsed = Float(baseString.dropFirst(iterator) ?? Float(-1)
+                    versionParsed = Float(baseString.dropFirst(iterator)) ?? Float(-1)
                     break; //we found the char
                 } else if i == ">" {
                     operatorType = 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -52,7 +52,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
+                        let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,25 +46,25 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = "," + (targetPackage.depends ?? "abcd") + ","
+                let deponfw = "," + (targetPackage.depends ?? "abcd")
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = (targetPackage.conflicts ?? "abcd") + ","
+                        let conflictwithfw = (targetPackage.conflicts ?? "abcd")
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
+                                let preDepends = "," + (targetPackage.preDepends ?? "abcd")
                                 if preDepends.contains("firmware") {
                                     if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
                                         targetPackage.isFirmwareConflict = true
                                     } else {
-                                        let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
+                                        let breaks = "," + (targetPackage.conflicts ?? "abcd")
                                         if breaks.contains("firmware") {
                                             if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                                 titleLabel?.textColor = UIColor.red
@@ -73,7 +73,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                         }
                                     }
                                 } else {
-                                    let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.breaks ?? "abcd")
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -83,13 +83,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
+                            let preDepends = "," + (targetPackage.preDepends ?? "abcd")
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.conflicts ?? "abcd")
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -98,7 +98,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.breaks ?? "abcd")
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -109,19 +109,19 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         }
                     }
                 } else {
-                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + ","
+                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
                             targetPackage.isFirmwareConflict = true
                         } else {
-                            let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
+                            let preDepends = "," + (targetPackage.preDepends ?? "abcd")
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.conflicts ?? "abcd")
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -130,7 +130,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.breaks ?? "abcd")
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -140,13 +140,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                             }
                         }
                     } else {
-                        let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
+                        let preDepends = "," + (targetPackage.preDepends ?? "abcd")
                         if preDepends.contains("firmware") {
                             if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.conflicts ?? "abcd")
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -155,7 +155,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
+                            let breaks = "," + (targetPackage.breaks ?? "abcd")
                             if breaks.contains("firmware") {
                                 if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,13 +46,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = "," + (targetPackage.depends ?? "abcd") + "," + (targetPackage.preDepends ?? "abcd")
+                let deponfw = targetPackage.depends ?? "abcd"
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
+                        let conflictwithfw = targetPackage.conflicts ?? "abcd"
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
@@ -61,7 +61,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         }
                     }
                 } else {
-                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
+                    let conflictwithfw = targetPackage.conflicts ?? "abcd"
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
@@ -484,7 +484,7 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
     private func doesNotDepend(confOrDependString: String, forVersion ver: Float) -> Bool {
         let noSpaceFull = confOrDependString.replacingOccurrences(of: " ", with: "");
         var noSpaceIter = 0
-        for noSpace in noSpaceFull.components(separatedBy: ",firmware")  { //support for two firmware depends in one field
+        for noSpace in noSpaceFull.components(separatedBy: "firmware(")  { //support for two firmware depends in one field
             if noSpaceIter == 0 {
                 noSpaceIter += 1
                 continue;

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,122 +46,26 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = "," + (targetPackage.depends ?? "abcd")
+                let deponfw = "," + (targetPackage.depends ?? "abcd") + "," + (targetPackage.preDepends ?? "abcd")
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = (targetPackage.conflicts ?? "abcd")
+                        let conflictwithfw = (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
-                            } else {
-                                let preDepends = "," + (targetPackage.preDepends ?? "abcd")
-                                if preDepends.contains("firmware") {
-                                    if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                        titleLabel?.textColor = UIColor.red
-                                        targetPackage.isFirmwareConflict = true
-                                    } else {
-                                        let breaks = "," + (targetPackage.conflicts ?? "abcd")
-                                        if breaks.contains("firmware") {
-                                            if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                                titleLabel?.textColor = UIColor.red
-                                                targetPackage.isFirmwareConflict = true
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    let breaks = "," + (targetPackage.breaks ?? "abcd")
-                                    if breaks.contains("firmware") {
-                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                            titleLabel?.textColor = UIColor.red
-                                            targetPackage.isFirmwareConflict = true
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            let preDepends = "," + (targetPackage.preDepends ?? "abcd")
-                            if preDepends.contains("firmware") {
-                                if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                    titleLabel?.textColor = UIColor.red
-                                    targetPackage.isFirmwareConflict = true
-                                } else {
-                                    let breaks = "," + (targetPackage.conflicts ?? "abcd")
-                                    if breaks.contains("firmware") {
-                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                            titleLabel?.textColor = UIColor.red
-                                            targetPackage.isFirmwareConflict = true
-                                        }
-                                    }
-                                }
-                            } else {
-                                let breaks = "," + (targetPackage.breaks ?? "abcd")
-                                if breaks.contains("firmware") {
-                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                        titleLabel?.textColor = UIColor.red
-                                        targetPackage.isFirmwareConflict = true
-                                    }
-                                }
                             }
                         }
                     }
                 } else {
-                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd")
+                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + "," + (targetPackage.breaks ?? "abcd")
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
                             targetPackage.isFirmwareConflict = true
-                        } else {
-                            let preDepends = "," + (targetPackage.preDepends ?? "abcd")
-                            if preDepends.contains("firmware") {
-                                if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                    titleLabel?.textColor = UIColor.red
-                                    targetPackage.isFirmwareConflict = true
-                                } else {
-                                    let breaks = "," + (targetPackage.conflicts ?? "abcd")
-                                    if breaks.contains("firmware") {
-                                        if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                            titleLabel?.textColor = UIColor.red
-                                            targetPackage.isFirmwareConflict = true
-                                        }
-                                    }
-                                }
-                            } else {
-                                let breaks = "," + (targetPackage.breaks ?? "abcd")
-                                if breaks.contains("firmware") {
-                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                        titleLabel?.textColor = UIColor.red
-                                        targetPackage.isFirmwareConflict = true
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        let preDepends = "," + (targetPackage.preDepends ?? "abcd")
-                        if preDepends.contains("firmware") {
-                            if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                titleLabel?.textColor = UIColor.red
-                                targetPackage.isFirmwareConflict = true
-                            } else {
-                                let breaks = "," + (targetPackage.conflicts ?? "abcd")
-                                if breaks.contains("firmware") {
-                                    if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                        titleLabel?.textColor = UIColor.red
-                                        targetPackage.isFirmwareConflict = true
-                                    }
-                                }
-                            }
-                        } else {
-                            let breaks = "," + (targetPackage.breaks ?? "abcd")
-                            if breaks.contains("firmware") {
-                                if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
-                                    titleLabel?.textColor = UIColor.red
-                                    targetPackage.isFirmwareConflict = true
-                                }
-                            }
                         }
                     }
                 }

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -585,11 +585,12 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
                 noSpaceIter += 1
                 continue;
             }
-            guard let endIndex = noSpace.range(of: ",", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound else {
+            let endIndex = (noSpace.range(of: ",", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound) ?? noSpace.endIndex
+            let baseString = String(noSpace[..<endIndex])
+            if baseString.count < 1 {
                 noSpaceIter += 1
                 continue
-            }
-            let baseString = String(noSpace[..<endIndex])
+            } //if baseString is blank, next one. you could also do same thing by checking if first character of baseString is "," or checking if endIndex is 0, not sure which one is faster, just went with this
             if baseString.contains("|") {
                 //something other than firmware
                 noSpaceIter += 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -491,10 +491,6 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             }
             let endIndex = (noSpace.range(of: "),", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound) ?? noSpace.endIndex
             let baseString = String(noSpace[..<endIndex])
-            if baseString.count < 1 {
-                noSpaceIter += 1
-                continue
-            } //if baseString is blank, next one. you could also do same thing by checking if first character of baseString is "," or checking if endIndex is 0, not sure which one is faster, just went with this
             if baseString.contains("|") {
                 //something other than firmware
                 noSpaceIter += 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -36,7 +36,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
         didSet {
             if let targetPackage = targetPackage {
                 titleLabel?.text = targetPackage.name
-                authorLabel?.text = "\(ControlFileParser.authorName(string: targetPackage.author ?? "")) • \(targetPackage.version)"
+                authorLabel?.text = ControlFileParser.authorName(string: targetPackage.author ?? "") + " • " + targetPackage.version
                 descriptionLabel?.text = targetPackage.packageDescription
                 
                 let url = targetPackage.icon
@@ -85,7 +85,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
         didSet {
             if let provisionalTarget = provisionalTarget {
                 titleLabel?.text = provisionalTarget.name ?? ""
-                authorLabel?.text = "\(provisionalTarget.author ?? "") • \(provisionalTarget.version ?? "Unknown")"
+                authorLabel?.text = (provisionalTarget.author ?? "") + " • " + (provisionalTarget.version ?? "Unknown")
                 descriptionLabel?.text = provisionalTarget.description
             
                 let url = provisionalTarget.icon

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,25 +46,25 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = "Depends: " + (targetPackage.depends ?? "boobs") + ","
+                let deponfw = "Depends: " + (targetPackage.depends ?? "abcd") + ","
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
                         targetPackage.isFirmwareConflict = true
                     } else {
-                        let conflictwithfw = (targetPackage.conflicts ?? "cock") + ","
+                        let conflictwithfw = (targetPackage.conflicts ?? "abcd") + ","
                         if conflictwithfw.contains("firmware") {
                             if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                                let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
                                 if preDepends.contains("firmware") {
                                     if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
                                         targetPackage.isFirmwareConflict = true
                                     } else {
-                                        let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                        let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
                                         if breaks.contains("firmware") {
                                             if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                                 titleLabel?.textColor = UIColor.red
@@ -73,7 +73,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                         }
                                     }
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                    let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -83,13 +83,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -98,7 +98,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -109,19 +109,19 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         }
                     }
                 } else {
-                    let conflictwithfw = "Conflicts: " + (targetPackage.conflicts ?? "cock") + ","
+                    let conflictwithfw = "Conflicts: " + (targetPackage.conflicts ?? "abcd") + ","
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
                             targetPackage.isFirmwareConflict = true
                         } else {
-                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -130,7 +130,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                                let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -140,13 +140,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                             }
                         }
                     } else {
-                        let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "boobies") + ","
+                        let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
                         if preDepends.contains("firmware") {
                             if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.conflicts ?? "cock") + ","
+                                let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -155,7 +155,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let breaks = "Breaks: " + (targetPackage.breaks ?? "cock") + ","
+                            let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
                             if breaks.contains("firmware") {
                                 if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -46,7 +46,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 
                 #if os(iOS)
                 
-                let deponfw = "Depends: " + (targetPackage.depends ?? "abcd") + ","
+                let deponfw = "," + (targetPackage.depends ?? "abcd") + ","
                 if deponfw.contains("firmware") {
                     if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                         titleLabel?.textColor = UIColor.red
@@ -58,13 +58,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
+                                let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
                                 if preDepends.contains("firmware") {
                                     if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
                                         targetPackage.isFirmwareConflict = true
                                     } else {
-                                        let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
+                                        let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
                                         if breaks.contains("firmware") {
                                             if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                                 titleLabel?.textColor = UIColor.red
@@ -73,7 +73,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                         }
                                     }
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -83,13 +83,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
+                            let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -98,7 +98,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -109,19 +109,19 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                         }
                     }
                 } else {
-                    let conflictwithfw = "Conflicts: " + (targetPackage.conflicts ?? "abcd") + ","
+                    let conflictwithfw = "," + (targetPackage.conflicts ?? "abcd") + ","
                     if conflictwithfw.contains("firmware") {
                         if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
                             titleLabel?.textColor = UIColor.red
                             targetPackage.isFirmwareConflict = true
                         } else {
-                            let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
+                            let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
                             if preDepends.contains("firmware") {
                                 if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
                                     targetPackage.isFirmwareConflict = true
                                 } else {
-                                    let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
+                                    let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
                                     if breaks.contains("firmware") {
                                         if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                             titleLabel?.textColor = UIColor.red
@@ -130,7 +130,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                     }
                                 }
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -140,13 +140,13 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                             }
                         }
                     } else {
-                        let preDepends = "Pre-Depends: " + (targetPackage.preDepends ?? "abcd") + ","
+                        let preDepends = "," + (targetPackage.preDepends ?? "abcd") + ","
                         if preDepends.contains("firmware") {
                             if doesNotDepend(confOrDependString: preDepends, forVersion: Float(UIDevice.current.systemVersion)!) {
                                 titleLabel?.textColor = UIColor.red
                                 targetPackage.isFirmwareConflict = true
                             } else {
-                                let breaks = "Breaks: " + (targetPackage.conflicts ?? "abcd") + ","
+                                let breaks = "," + (targetPackage.conflicts ?? "abcd") + ","
                                 if breaks.contains("firmware") {
                                     if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                         titleLabel?.textColor = UIColor.red
@@ -155,7 +155,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                                 }
                             }
                         } else {
-                            let breaks = "Breaks: " + (targetPackage.breaks ?? "abcd") + ","
+                            let breaks = "," + (targetPackage.breaks ?? "abcd") + ","
                             if breaks.contains("firmware") {
                                 if !doesNotDepend(confOrDependString: breaks, forVersion: Float(UIDevice.current.systemVersion)!) {
                                     titleLabel?.textColor = UIColor.red
@@ -580,23 +580,16 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
     private func doesNotDepend(confOrDependString: String, forVersion ver: Float) -> Bool {
         let noSpaceFull = confOrDependString.replacingOccurrences(of: " ", with: "");
         var noSpaceIter = 0
-        for noSpacet in noSpaceFull.components(separatedBy: ",firmware")  { //support for two firmware depends in one field
-            var noSpace = ""
+        for noSpace in noSpaceFull.components(separatedBy: ",firmware")  { //support for two firmware depends in one field
             if noSpaceIter == 0 {
-                if !noSpaceFull.contains(":firmware") { //handle if :firmware
-                    noSpaceIter += 1
-                    continue;
-                } else {
-                    noSpace = noSpacet
-                }
-            } else {
-                noSpace = "firmware" + noSpacet
+                noSpaceIter += 1
+                continue;
             }
-            guard let startIndex = noSpace.range(of: "firmware")?.upperBound, let endIndex = noSpace.range(of: ",", options: .init(rawValue: 0), range: startIndex..<noSpace.endIndex, locale: nil)?.lowerBound else {
+            guard let endIndex = noSpace.range(of: ",", options: .init(rawValue: 0), range: noSpace.startIndex..<noSpace.endIndex, locale: nil)?.lowerBound else {
                 noSpaceIter += 1
                 continue
             }
-            let baseString = String(noSpace[startIndex..<endIndex])
+            let baseString = String(noSpace[..<endIndex])
             if baseString.contains("|") {
                 //something other than firmware
                 noSpaceIter += 1

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -493,7 +493,6 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             let baseString = String(noSpace[..<endIndex])
             if baseString.contains("|") {
                 //something other than firmware
-                noSpaceIter += 1
                 continue //we don't actually want to mark as red if something other than the firmware conflicts, so firmware (>= 13.0) | somedeb gets marked as false even if firmware is lower than 13.0, since somedeb isn't firmware
             }
             var operatorType = 0
@@ -520,10 +519,8 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             }
             if versionParsed == -1 {
                 print("COULD NOT FIND VERSIONPARSED")
-                noSpaceIter += 1
                 continue
             }
-            noSpaceIter += 1
             switch operatorType {
                 case 1: if (versionParsed >= ver) {return versionParsed >= ver}
                 case 2: if (versionParsed <= ver) {return versionParsed <= ver}

--- a/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
+++ b/Sileo/UI/PackageListViewController/PackageCell/PackageCollectionViewCell.swift
@@ -42,6 +42,35 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
                 EvanderNetworking.image(url: url, condition: { [weak self] in self?.targetPackage?.icon == url }, imageView: imageView, fallback: targetPackage.defaultIcon)
                         
                 titleLabel?.textColor = targetPackage.commercial ? self.tintColor : .sileoLabel
+                
+                //#if os(iOS)
+
+                let deponfw = (targetPackage.depends ?? "Depends: firmware (>= 0.0)") + ","
+
+                if deponfw.contains("firmware") {
+                    if doesNotDepend(confOrDependString: deponfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                        titleLabel?.textColor = UIColor.red
+                        targetPackage.isFirmwareConflict = true
+                    } else {
+                        let conflictwithfw = (targetPackage.conflicts ?? "Conflicts: firmware (>= 9999999.0)") + ","
+                        if conflictwithfw.contains("firmware") {
+                            if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                                titleLabel?.textColor = UIColor.red
+                                targetPackage.isFirmwareConflict = true
+                            }
+                        }
+                    }
+                } else {
+                    let conflictwithfw = (targetPackage.conflicts ?? "Conflicts: firmware (>= 9999999.0)") + ","
+                    if conflictwithfw.contains("firmware") {
+                        if !doesNotDepend(confOrDependString: conflictwithfw, forVersion: Float(UIDevice.current.systemVersion)!) {
+                            titleLabel?.textColor = UIColor.red
+                            targetPackage.isFirmwareConflict = true
+                        }
+                    }
+                }
+
+                //#endif
             }
             unreadView?.isHidden = true
             
@@ -104,7 +133,7 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
     }
     
     @objc func updateSileoColors() {
-        if !(targetPackage?.commercial ?? false) {
+        if !(targetPackage?.commercial ?? false) && !(targetPackage?.isFirmwareConflict ?? false) {
             titleLabel?.textColor = .sileoLabel
         }
     }
@@ -132,8 +161,12 @@ class PackageCollectionViewCell: SwipeCollectionViewCell {
     override func tintColorDidChange() {
         super.tintColorDidChange()
         
-        if targetPackage?.commercial ?? false {
-            titleLabel?.textColor = self.tintColor
+        if targetPackage?.isFirmwareConflict ?? false {
+            titleLabel?.textColor = UIColor.red
+        } else {
+            if targetPackage?.commercial ?? false {
+                titleLabel?.textColor = self.tintColor
+            }
         }
         
         unreadView?.backgroundColor = self.tintColor
@@ -443,5 +476,76 @@ extension PackageCollectionViewCell: SwipeCollectionViewCellDelegate {
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
         }
+    }
+    
+    //Thanks to Serena for original function, this is changed by me (Snoolie/0xilis) from the original to fix some bugs and make it slightly faster.
+    //This function is licensed under MIT at https://github.com/0xilis/SileoRedLabelFirmwareConflict
+    //It take in a Depends (or Pre-Depends) and will return true if the firmware is in regards
+    private func doesNotDepend(confOrDependString: String, forVersion ver: Float) -> Bool {
+        let noSpaceFull = confOrDependString.replacingOccurrences(of: " ", with: "");
+        var noSpaceIter = 0
+        for noSpacet in noSpaceFull.components(separatedBy: ",firmware")  { //support for two firmware depends in one field
+            var noSpace = ""
+            if noSpaceIter == 0 {
+                if !noSpaceFull.contains(":firmware") { //handle if :firmware
+                    noSpaceIter += 1
+                    continue;
+                } else {
+                    noSpace = noSpacet
+                }
+            } else {
+                noSpace = "firmware" + noSpacet
+            }
+            guard let startIndex = noSpace.range(of: "firmware")?.upperBound, let endIndex = noSpace.range(of: ",", options: .init(rawValue: 0), range: startIndex..<noSpace.endIndex, locale: nil)?.lowerBound else {
+                noSpaceIter += 1
+                continue
+            }
+            let baseString = String(noSpace[startIndex..<endIndex]).replacingOccurrences(of: ")", with: "") //we shouldn't need to remove (, only )
+            if baseString.contains("|") {
+                print("something other than firmware")
+                noSpaceIter += 1
+                continue //we don't actually want to mark as red if something other than the firmware conflicts, so firmware (>= 13.0) | somedeb gets marked as false even if firmware is lower than 13.0, since somedeb isn't firmware
+            }
+            var operatorType = 0
+            //operatorTypes:
+            //> / >> are 1
+            //< / << are 2
+            //= is 3
+            //>= is 4
+            //<= is 5
+            var iterator = 0
+            var versionParsed = Float(-1)
+            for i in baseString {
+                if i.isWholeNumber {
+                    versionParsed = Float(baseString.dropFirst(iterator)) ?? Float(-1)
+                    break; //we found the char
+                } else if i == ">" {
+                    operatorType = 1
+                } else if i == "<" {
+                    operatorType = 2
+                } else if i == "=" {
+                    operatorType += 3
+                }
+                iterator += 1
+            }
+            if versionParsed == -1 {
+                print("COULD NOT FIND VERSIONPARSED")
+                print(confOrDependString)
+                print(baseString)
+                print(noSpaceIter)
+                noSpaceIter += 1
+                continue
+            }
+            noSpaceIter += 1
+            switch operatorType {
+                case 1: if (versionParsed >= ver) {return versionParsed >= ver}
+                case 2: if (versionParsed <= ver) {return versionParsed <= ver}
+                case 4: if (versionParsed > ver) {return versionParsed > ver}
+                case 5: if (versionParsed < ver) {return versionParsed < ver}
+                case 3: if (versionParsed != ver) {return versionParsed != ver}
+                default: continue;
+            }
+        }
+        return false
     }
 }

--- a/Sileo/UI/PackageListViewController/PackageListViewController.swift
+++ b/Sileo/UI/PackageListViewController/PackageListViewController.swift
@@ -327,7 +327,7 @@ class PackageListViewController: SileoViewController, UIGestureRecognizerDelegat
             }
             let packageVersion = package.version
             
-            bodyFromArray += "\(packageName): \(packageVersion)\n"
+            bodyFromArray += (packageName + ": " + packageVersion + "\n")
         }
         
         if let subRange = Range<String.Index>(NSRange(location: bodyFromArray.count - 1, length: 1), in: bodyFromArray) {

--- a/Sileo/UI/PackageViewController/PackageViewController.swift
+++ b/Sileo/UI/PackageViewController/PackageViewController.swift
@@ -128,7 +128,11 @@ class PackageViewController: SileoViewController, PackageQueueButtonDataProvider
                                                name: SileoThemeManager.sileoChangedThemeNotification,
                                                object: nil)
         
-        packageName.textColor = .sileoLabel
+        if (package?.isFirmwareConflict ?? false) {
+            packageName.textColor = UIColor.red
+        } else {
+            packageName.textColor = .sileoLabel
+        }
         let collapsed = splitViewController?.isCollapsed ?? false
         let navController = collapsed ? (splitViewController?.viewControllers[0] as? UINavigationController) : self.navigationController
         navController?.setNavigationBarHidden(true, animated: true)
@@ -203,7 +207,11 @@ class PackageViewController: SileoViewController, PackageQueueButtonDataProvider
     }
 
     @objc func updateSileoColors() {
-        packageName.textColor = .sileoLabel
+        if (package?.isFirmwareConflict ?? false) {
+            packageName.textColor = UIColor.red
+        } else {
+            packageName.textColor = .sileoLabel
+        }
     }
     
     @objc func reloadData() {

--- a/Sileo/UI/PackageViewController/PackageViewController.swift
+++ b/Sileo/UI/PackageViewController/PackageViewController.swift
@@ -567,9 +567,9 @@ class PackageViewController: SileoViewController, PackageQueueButtonDataProvider
         
         let sharePopup = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let shareAction = UIAlertAction(title: String(localizationKey: "Package_Share_Action"), style: .default) { _ in
-            var packageString = "\(package.name ?? package.package) - \(URLManager.url(package: package.package))"
+            var packageString = (package.name ?? package.package) + " - " + URLManager.url(package: package.package)
             if let repo = package.sourceRepo {
-                packageString += " - from \(repo.url?.absoluteString ?? repo.rawURL)"
+                packageString += " - from " + (repo.url?.absoluteString ?? repo.rawURL)
             }
             let activityViewController = UIActivityViewController(activityItems: [packageString], applicationActivities: nil)
             activityViewController.popoverPresentationController?.sourceView = shareButton
@@ -582,7 +582,7 @@ class PackageViewController: SileoViewController, PackageQueueButtonDataProvider
             let moreByDeveloper = UIAlertAction(title: String(localizationKey: "Package_Developer_Find_Action"
             ), style: .default) { _ in
                 let packagesListController = PackageListViewController(nibName: "PackageListViewController", bundle: nil)
-                packagesListController.packagesLoadIdentifier = "author:\(email)"
+                packagesListController.packagesLoadIdentifier = "author:" + email
                 packagesListController.title = String(format: String(localizationKey: "Packages_By_Author"),
                                                       ControlFileParser.authorName(string: author))
                 self.navigationController?.pushViewController(packagesListController, animated: true)


### PR DESCRIPTION
Basically, a **much** better version of https://github.com/Sileo/Sileo/pull/229

Fixes compared to original PR:
- `>=` / `<=` no longer act as `>>` / `<<`
- Extra spaces no longer make Sileo crash
- More optimized
- Now handles multiple instances of firmware in one Depends/Conflicts
- Add support for Pre-Depends and Breaks
- No longer breaks upon updating colors

This PR makes the label on packages red if the firmware conflicts. Doesn't affect other dependences that the user doesn't have since most of the time an external dependency can just be installed. I believe this should make searching for packages that support your device in Sileo much easier.

I checked and verified it working on Xcode Sim 15.4. Should also be compliant with https://www.debian.org/doc/debian-policy/ch-relationships.html. If I need to change anything, let me know.