### PR TITLE
Add finish:usreboot for userspace reboot

### DIFF
--- a/Sileo/Backend/APT Wrapper/APTWrapper.swift
+++ b/Sileo/Backend/APT Wrapper/APTWrapper.swift
@@ -21,6 +21,7 @@ class APTWrapper {
         case restart = 3
         case reload = 4
         case reboot = 5
+        case usreboot = 6
     }
 
     static let GNUPGPREFIX = "[GNUPG:]"
@@ -437,6 +438,9 @@ class APTWrapper {
                             }
                             if sileoLine.hasPrefix("finish:reboot") {
                                 newFinish = .reboot
+                            }
+                            if sileoLine.hasPrefix("finish:usreboot") {
+                                newFinish = .usreboot
                             }
 
                             if newFinish.rawValue > finish.rawValue {

--- a/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
+++ b/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
@@ -628,6 +628,9 @@ class DownloadsTableViewController: SileoViewController {
         case .reboot:
             completeButton?.setTitle(String(localizationKey: "After_Install_Reboot"), for: .normal)
             completeLaterButton?.setTitle(String(localizationKey: "After_Install_Reboot_Later"), for: .normal)
+        case .usreboot:
+            completeButton?.setTitle(String(localizationKey: "After_Install_Reboot"), for: .normal)
+            completeLaterButton?.setTitle(String(localizationKey: "After_Install_Reboot_Later"), for: .normal)
         case .uicache:
             if refreshSileo {
                 completeButton?.setTitle(String(localizationKey: "After_Install_Relaunch"), for: .normal)

--- a/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
+++ b/Sileo/UI/DownloadsViewController/DownloadsTableViewController.swift
@@ -448,6 +448,9 @@ class DownloadsTableViewController: SileoViewController {
             case .reboot:
                 spawnAsRoot(args: ["\(CommandPath.prefix)/usr/bin/sync"])
                 spawnAsRoot(args: ["\(CommandPath.prefix)/usr/bin/ldrestart"])
+            case .usreboot:
+                spawnAsRoot(args: ["\(CommandPath.prefix)/usr/bin/sync"])
+                spawnAsRoot(args: ["\(CommandPath.prefix)/usr/bin/launchctl", "reboot", "userspace"])
             }
         }
         // Fire the animation


### PR DESCRIPTION
Add `finish:usreboot` so packages can request to userspace reboot instead of ldrestart. An example of this is ElleKit, where an ldrestart won't start it correctly.