### PR TITLE
Remove XinaA15 not supported notice, account for XinaA15 1.x/2.x

### DIFF
--- a/Sileo/Backend/Root Wrapper/Bootstrap.swift
+++ b/Sileo/Backend/Root Wrapper/Bootstrap.swift
@@ -33,13 +33,10 @@ enum Bootstrap: String, Codable {
                 self = .electra_strap
             }
             
-        case .unc0ver:
+        case .unc0ver, .checkra1n:
             self = .elucubratus
             
-        case .checkra1n:
-            self = .elucubratus
-            
-        case .odysseyra1n, .taurine, .odyssey:
+        case .odysseyra1n, .taurine, .odyssey, .fugu15, .xina15, .dopamine:
             self = .procursus
             
         case .palera1n_legacy, .palera1n_rootful, .palera1n_rootless, .bakera1n_rootful, .bakera1n_rootless:
@@ -49,7 +46,7 @@ enum Bootstrap: String, Codable {
                 self = .other_strap
             }
             
-        case .xina15:
+        case .xina15_legacy:
             self = .xinaa15_strap
             
         default:

--- a/Sileo/Backend/Root Wrapper/Jailbreak.swift
+++ b/Sileo/Backend/Root Wrapper/Jailbreak.swift
@@ -37,6 +37,7 @@ enum Jailbreak: String, Codable {
     case bakera1n_rootful =  "bakera1n • Rootful"
     
     /// Xina
+    case xina15_legacy =     "XinaA15 • Legacy"
     case xina15 =            "XinaA15"
     
     /// Fugu15
@@ -64,7 +65,7 @@ enum Jailbreak: String, Codable {
         
         .bakera1n, .bakera1n_rootful, .bakera1n_rootless,
         
-        .fugu15, .dopamine
+        .fugu15, .xina, .dopamine
     ]
     
     public var supportsUserspaceReboot: Bool {
@@ -82,7 +83,8 @@ enum Jailbreak: String, Codable {
         let palera1n = URL(fileURLWithPath: "/cores/jbloader")
         let palera1n_Legacy = URL(fileURLWithPath: "/jbin/post.sh")
         
-        let xina = URL(fileURLWithPath: "/var/Liy/.procursus_strapped")
+        let xina = URL(fileURLWithPath: "/var/jb/.installed_xina15")
+        let xina_Legacy = URL(fileURLWithPath: "/var/Liy/.procursus_strapped")
         let fugu15_max = URL(fileURLWithPath: "/var/jb/.installed_fugu15max")
         let dopamine = URL(fileURLWithPath: "/var/jb/.installed_dopamine")
         
@@ -127,6 +129,10 @@ enum Jailbreak: String, Codable {
             // arm64e 15.0+ jailbreaks
         case xina.exists && arm64e:
             self = .xina15
+            return
+
+        case xina_Legacy.exists && arm64e:
+            self = .xina15_legacy
             return
             
         case fugu15_max.exists && arm64e:

--- a/Sileo/UI/FeaturedViewController/FeaturedViewController.swift
+++ b/Sileo/UI/FeaturedViewController/FeaturedViewController.swift
@@ -241,20 +241,6 @@ final class FeaturedViewController: SileoViewController, UIScrollViewDelegate, F
         self.reloadData()
         updateSileoColors()
     }
-    
-    private class func showXinaWarning() {
-        let alert = UIAlertController(title: "XinaA15 no longer supported", message: "XinaA15 is no longer supported by Sileo, as recent changes make it impossible for Sileo to support XinaA15 in a functional manner. Please remove XinaA15 and switch to Fugu15 Max.", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Guide", style: .default) { _ in
-            UIApplication.shared.open(URL(string: "https://ios.cfw.guide/installing-fugu15max/")!)
-            exit(0)
-        })
-        alert.addAction(UIAlertAction(title: "Close", style: .destructive) { _ in
-            exit(0)
-        })
-        Thread.mainBlock {
-            TabBarController.singleton?.present(alert, animated: true)
-        }
-    }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -264,10 +250,6 @@ final class FeaturedViewController: SileoViewController, UIScrollViewDelegate, F
         
         self.navigationController?.navigationBar.superview?.tag = WHITE_BLUR_TAG
         self.navigationController?.navigationBar._hidesShadow = true
-        
-        if Jailbreak.current == .xina15 {
-            Self.showXinaWarning()
-        }
         
         FRUIView.animate(withDuration: 0.2) {
             self.profileButton?.alpha = 1.0


### PR DESCRIPTION
Note (for outside watchers): This won't fix XinaA15 1.x whatsoever (it's still broken) - this just removes the notice so people who aren't the smartest and left XinaA15 1.x installed when switching to XinaA15 2.x won't see the notice.

...users will still need to figure out how to install an updated Sileo (either that, or Xina needs to ship an update with an updated Sileo)